### PR TITLE
brew install boost --c++11

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ For Ubuntu Linux, the following should help a bit:
 
 On a Mac, get the homebrew package manager and:
 
-    brew install cmake gmp mpfr libmpc boost bison
+    brew install boost --c++11
+    brew install cmake gmp mpfr libmpc bison
 
 In theory, you can also run Retro68 on a PowerMac G4 or G5 running Mac OS 10.4 (Tiger).
 In that case, get the tigerbrew package manager and


### PR DESCRIPTION
I ran into problems by having a boost already installed, just not with --c++11. Removing and re-installing fixed it.
This PR may provide enough of a hint to new users, but I'm not sure.