### PR TITLE
Update README to no longer use the c++11 option when installing boost

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For Ubuntu Linux, the following should help a bit:
 
 On a Mac, get the homebrew package manager and:
 
-    brew install boost --c++11
+    brew install boost
     brew install cmake gmp mpfr libmpc bison
 
 You can also run Retro68 on a PowerMac G4 or G5 running Mac OS 10.4 (Tiger).


### PR DESCRIPTION
The option was removed from the package in https://github.com/Homebrew/homebrew-core/commit/7db3553e07d08e3c36689b62b9dea1732abe257d
`tigerbrew` has not picked that up yet, so keep the option when building on Tiger

Fixes issue #54 