### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Installing/Building
 
 For Ubuntu Linux, the following should help a bit:
 
-    sudo apt-get install cmake libgmp-dev libmpfr-dev libmpc-dev libboost-all-dev bison
+    sudo apt-get install cmake libgmp-dev libmpfr-dev libmpc-dev libboost-all-dev bison texinfo
 
 On a Mac, get the homebrew package manager and:
 


### PR DESCRIPTION
build-toolchain fails on ubuntu unless you have 'makeinfo' binary, which is part of 'texinfo' package