### PR TITLE
Update build-toolchain.bash

### DIFF
--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -516,11 +516,12 @@ for arch in $ARCHS; do
 		"$PREFIX/bin/${arch}-apple-macos-ar" cqs "$PREFIX/${arch}-apple-macos/lib/libretrocrt.a"
 	fi
 done
-if [ ! -e "$PREFIX/powerpc-apple-macos/lib/libretrocrt-carbon.a" ]; then
-    echo "Creating dummy libretrocrt-carbon.a for $arch..."
-    "$PREFIX/bin/powerpc-apple-macos-ar" cqs "$PREFIX/powerpc-apple-macos/lib/libretrocrt-carbon.a"
+if [ $BUILD_PPC != false ]; then
+	if [ ! -e "$PREFIX/powerpc-apple-macos/lib/libretrocrt-carbon.a" ]; then
+    		echo "Creating dummy libretrocrt-carbon.a for $arch..."
+    		"$PREFIX/bin/powerpc-apple-macos-ar" cqs "$PREFIX/powerpc-apple-macos/lib/libretrocrt-carbon.a"
+	fi
 fi
-
 	# the real libretrocrt.a is built and installed by 
 	# `cmake --build build-target --target install` later
 


### PR DESCRIPTION
the --no-ppc --no-carbon  build was broken because it was looking for ppc tools anyways. this allows it to at least get through the script.