### PR TITLE
Update build-toolchain.bash

### DIFF
--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -162,6 +162,18 @@ fi
 
 INTERFACES_DIR="$SRC/InterfacesAndLibraries"
 
+function verifyInterfaceDirNames()
+{
+        printf "Searching for special characters in subdirs of $INTERFACES_DIR"
+        local found=`find "$INTERFACES_DIR" -name ".*" -print `
+        if [ "`echo $found | grep \&`" ]; then
+                echo "\n$found Contained special character &"
+                return 1        # failure
+        else
+                return 0        # success
+        fi
+}
+
 function locateInterfaceThing()
 {
 	local varname=$1
@@ -197,6 +209,15 @@ function explainInterfaces()
 }
 
 echo "Looking for various files in $INTERFACES_DIR/..."
+
+if verifyInterfaceDirNames; then
+        echo "Directory name looks clean"
+else
+        echo "Directory name contained special character & that would break build"
+        echo "Please install the Interfaces and Libraries files in a path under"
+        echo "$INTERFACES_DIR that does not contain the & character"
+        exit 1
+fi
 
 if locateInterfaceThing CONDITIONALMACROS_H ConditionalMacros.h; then
 	CINCLUDES=`dirname "$CONDITIONALMACROS_H"`

--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -165,7 +165,7 @@ INTERFACES_DIR="$SRC/InterfacesAndLibraries"
 function verifyInterfaceDirNames()
 {
         printf "Searching for special characters in subdirs of $INTERFACES_DIR"
-        local found=`find "$INTERFACES_DIR" -name ".*" -print `
+        local found=`find "$INTERFACES_DIR" -type d -name "*" -print `
         if [ "`echo $found | grep \&`" ]; then
                 echo "\n$found Contained special character &"
                 return 1        # failure


### PR DESCRIPTION
check the directories where the interfaces and libraries are installed to make sure they dont contain the '&' character, which breaks the build on linux. (some archives of the interfaces and libraries files, have them named as "Interfaces&Libraries")