### PR TITLE
Fix header processing on non en_US locales

### DIFF
--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -435,7 +435,7 @@ fi # SKIP_THIRDPARTY
 echo "Building host-based tools..."
 
 # Copy PEFBinaryFormat.h from Universal Interfaces, needed by MakePEF & MakeImport
-(export LANG=en; sed 's/\r$//' < "$CINCLUDES/PEFBinaryFormat.h" | tr '\r' '\n' > "toolchain/include/PEFBinaryFormat.h")
+(export LC_ALL=C; sed 's/\r$//' < "$CINCLUDES/PEFBinaryFormat.h" | tr '\r' '\n' > "toolchain/include/PEFBinaryFormat.h")
 
 mkdir -p build-host
 cd build-host

--- a/prepare-headers.sh
+++ b/prepare-headers.sh
@@ -2,7 +2,7 @@ IN=$1
 OUT=$2
 
 # Make Mac OS X's tr and sed not complain that the files are not UTF-8
-export LANG=en
+export LC_ALL=C
 
 for file in $(cd $IN; ls *.h); do
 	# Filter by file names.

--- a/prepare-rincludes.sh
+++ b/prepare-rincludes.sh
@@ -2,7 +2,7 @@ IN=$1
 OUT=$2
 
 # Make Mac OS X's tr and sed not complain that the files are not UTF-8
-export LANG=en
+export LC_ALL=C
 
 # cp $IN/[A-Z]*.r $OUT/
 for file in $(cd $IN; ls [A-Z]*.r); do


### PR DESCRIPTION
Uses LC_ALL=C instead LANG=C to get sed and tr to not throw errors when processing includes.

I had to do this to get build-toolchain to work on OS X with a locale of en_GB.UTF-8 as LC_ALL can override LANG.