### PR TITLE
Move man pages for hfsutils to share/man

### DIFF
--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -299,11 +299,11 @@ if [ $SKIP_THIRDPARTY != true ]; then
 
 	# Build hfsutil
 	mkdir -p $PREFIX/lib
-	mkdir -p $PREFIX/man/man1
+	mkdir -p $PREFIX/share/man/man1
 	rm -rf hfsutils
 	cp -r $SRC/hfsutils .
 	cd hfsutils
-	./configure --prefix=$PREFIX --enable-devlibs
+	./configure --prefix=$PREFIX --mandir=$PREFIX/share/man --enable-devlibs
 	make
 	make install
 	cd ..


### PR DESCRIPTION
This is only necessary for Homebrew. However, it makes sense in general,
it is where the other man pages lie.