### PR TITLE
Clarify how to initialize multiversal submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ are free software. However, they are incomplete and may still contain serious
 bugs. Missing things include Carbon, MacTCP, OpenTransport, Navigation Services,
 and basically everything introduced after System 7.0.
 
+If you'd like to use the Multiversal Interfaces, and you've already cloned the
+Retro68 repository, make sure the Multiversal submodule has been initialized:
+
+    cd Retro68
+    git submodule update --init
+
+If you haven't yet cloned the repository, just clone it and the submodule contents
+at the same time by using `git clone`'s `--recursive` option.
+
 The Universal Interfaces used to be a free download from Apple. However,
 they have taken the site off-line and the license agreement does not allow
 redistribution, which is why it's not included in this repository.


### PR DESCRIPTION
After coming back to retro68 after a while, compilation failed because the multiversal ruby script couldn't be found. I realized I had failed to clone the project including the submodule. Just clarifying the docs.

This script was executed even when using the official interfaces (`INTERFACES_KIND` was set to `universal`, so the detection was working properly), I can try to debug this if you want.