### PR TITLE
add support for R_68K_PC32 relocations

### DIFF
--- a/AutomatedTests/CMakeLists.txt
+++ b/AutomatedTests/CMakeLists.txt
@@ -75,6 +75,10 @@ if(CMAKE_SYSTEM_NAME MATCHES Retro68)
         LINK_FLAGS "-Wl,-gc-sections -Wl,--mac-segments -Wl,${CMAKE_CURRENT_SOURCE_DIR}/Segments.segmap")
     add_test(NAME ${TESTCASE_PREFIX}Segments COMMAND ${LAUNCH_APPL}
         ${LAUNCH_METHOD_FLAG} ${RETRO68_TEST_CONFIG} Segments.bin)
+
+
+    test(PCRel32.c PROPERTIES PASS_REGULAR_EXPRESSION "OK")
+    target_compile_options(PCRel32 PRIVATE -march=68020)
 endif()
 
 test(Exceptions.cc PROPERTIES PASS_REGULAR_EXPRESSION "OK")

--- a/AutomatedTests/PCRel32.c
+++ b/AutomatedTests/PCRel32.c
@@ -1,0 +1,29 @@
+#include "Test.h"
+#include <stdlib.h>
+
+__attribute__((noinline)) static void* foo(size_t x)
+{
+    return malloc(x);  
+}
+
+int main()
+{
+    if(*(short*)&foo != 0x60FF)
+    {
+        TEST_LOG_NO();
+        return 0;
+    }
+
+    uint32_t offset = *(uint32_t*) ((char*)&foo + 2);
+    if(((char*)&foo + 2) + offset != (char*)&malloc)
+    {
+        TEST_LOG_NO();
+        return 0;
+    }
+
+    char *p = foo(42);
+    strcpy(p, "OK");
+    TestLog(p);
+    free(p);
+    return 0;
+}

--- a/AutomatedTests/Test.h
+++ b/AutomatedTests/Test.h
@@ -87,8 +87,8 @@ void TestLog(const char *str);
 #define TEST_LOG_NO()    \
     do { \
         char no[3]; \
-        no[0] = 'O'; \
-        no[1] = 'K'; \
+        no[0] = 'N'; \
+        no[1] = 'O'; \
         no[2] = '\0'; \
         TEST_LOG_SIZED(no, 2); \
     } while(0)

--- a/Elf2Mac/Reloc.cc
+++ b/Elf2Mac/Reloc.cc
@@ -44,26 +44,33 @@ std::string SerializeRelocsUncompressed(std::vector<RuntimeReloc> relocs)
 std::string SerializeRelocs(std::vector<RuntimeReloc> relocs)
 {
     std::ostringstream out;
-    uint32_t offset = -1;
 
-    for(const auto& r : relocs)
+    for(int relative = 0; relative <= 1; relative++)
     {
-        uint32_t delta = r.offset - offset;
-        offset = r.offset;
+        uint32_t offset = -1;
 
-        uint32_t base = (uint32_t) r.base;
-
-        uint32_t encoded = (delta << 2) | base;
-
-        while(encoded >= 128)
+        for(const auto& r : relocs)
         {
-            byte(out, (encoded & 0x7F) | 0x80);
-            encoded >>= 7;
-        }
-        byte(out, encoded);
-    }
+            if(r.relative == (bool)relative)
+            {
+                uint32_t delta = r.offset - offset;
+                offset = r.offset;
 
-    byte(out, 0);
+                uint32_t base = (uint32_t) r.base;
+
+                uint32_t encoded = (delta << 2) | base;
+
+                while(encoded >= 128)
+                {
+                    byte(out, (encoded & 0x7F) | 0x80);
+                    encoded >>= 7;
+                }
+                byte(out, encoded);
+            }
+        }
+
+        byte(out, 0);
+    }
 
     return out.str();
 }

--- a/Elf2Mac/Reloc.h
+++ b/Elf2Mac/Reloc.h
@@ -47,11 +47,11 @@ public:
 class RuntimeReloc
 {
 public:
-    RelocBase base;
-    uint32_t offset;
+    RelocBase base = RelocBase::code;
+    uint32_t offset = 0;
+    bool relative = false;
 
-    RuntimeReloc() : base(RelocBase::code), offset(0) {}
-    RuntimeReloc(RelocBase b, uint32_t o) : base(b), offset(o) {}
+    RuntimeReloc(RelocBase b = RelocBase::code, uint32_t o = 0, bool r = false) : base(b), offset(o), relative(r) {}
 };
 
 std::string SerializeRelocsUncompressed(std::vector<RuntimeReloc> relocs);


### PR DESCRIPTION
Fix (well, implement) R_68K_PC32 relocations, which should fix crashes with 68020 and 68040 code (#38)

WIP: single-segment app support might or might not be broken at the moment.
