### PR TITLE
Allow skipping the build of hfsutils

### DIFF
--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -37,7 +37,7 @@ fi
 ##################### Command-line Options
 
 SKIP_THIRDPARTY=false
-SKIP_HFSUTILS=false
+WITH_SYSTEM_HFSUTILS=false
 BUILD_68K=true
 BUILD_PPC=true
 BUILD_CARBON=true
@@ -52,7 +52,7 @@ function usage()
 	echo "Options: "
 	echo "    --prefix                  the path to install the toolchain to"
 	echo "    --skip-thirdparty         do not rebuild gcc & third party libraries"
-	echo "    --skip-hfsutils           do not rebuild hfsutils (--skip-thirdparty will also skip hfsutils)"
+	echo "    --with-system-hfsutils    use system hfsutils (--skip-thirdparty will also skip building hfsutils)"
 	echo "    --no-68k                  disable support for 68K Macs"
 	echo "    --no-ppc                  disable classic PowerPC CFM support"
 	echo "    --no-carbon               disable Carbon CFM support"
@@ -73,8 +73,8 @@ for ARG in $*; do
 		--skip-thirdparty)
 			SKIP_THIRDPARTY=true
 			;;
-		--skip-hfsutils)
-			SKIP_HFSUTILS=true
+		--with-system-hfsutils)
+			WITH_SYSTEM_HFSUTILS=true
 			;;
 		--no-68k)
 			BUILD_68K=false
@@ -160,7 +160,7 @@ if [ $SKIP_THIRDPARTY != false ]; then
 		if [ ! -d binutils-build-ppc ]; then MISSING=true; fi
 		if [ ! -d gcc-build-ppc ]; then MISSING=true; fi
 	fi
-	if [ $SKIP_HFSUTILS = false -a ! -d hfsutils ]; then MISSING=true; fi
+	if [ $WITH_SYSTEM_HFSUTILS = false -a ! -d hfsutils ]; then MISSING=true; fi
 
 	if [ $MISSING != false ]; then
 		echo "Not all third-party components have been built yet, ignoring --skip-thirdparty."
@@ -311,7 +311,7 @@ if [ $SKIP_THIRDPARTY != true ]; then
 	unset CPPFLAGS
 	unset LDFLAGS
 
-	if [ $SKIP_HFSUTILS = false ]; then
+	if [ $WITH_SYSTEM_HFSUTILS = false ]; then
 		# Build hfsutils
 		mkdir -p $PREFIX/lib
 		mkdir -p $PREFIX/share/man/man1

--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -163,7 +163,7 @@ if [ $SKIP_THIRDPARTY != false ]; then
 	if [ $WITH_SYSTEM_HFSUTILS = false -a ! -d hfsutils ]; then MISSING=true; fi
 
 	if [ $MISSING != false ]; then
-		echo "Not all third-party components have been built yet, ignoring --skip-thirdparty."
+		echo "Not all third-party components have been built yet; ignoring --skip-thirdparty and --with-system-hfsutils."
 		SKIP_THIRDPARTY=false
 	fi
 fi

--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -311,7 +311,7 @@ if [ $SKIP_THIRDPARTY != true ]; then
 	unset CPPFLAGS
 	unset LDFLAGS
 
-	if [ $SKIP_HFSUTILS != false ]; then
+	if [ $SKIP_HFSUTILS = false ]; then
 		# Build hfsutils
 		mkdir -p $PREFIX/lib
 		mkdir -p $PREFIX/share/man/man1

--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -160,7 +160,7 @@ if [ $SKIP_THIRDPARTY != false ]; then
 		if [ ! -d binutils-build-ppc ]; then MISSING=true; fi
 		if [ ! -d gcc-build-ppc ]; then MISSING=true; fi
 	fi
-	if [ $SKIP_HFSUTILS != false -a ! -d hfsutils ]; then MISSING=true; fi
+	if [ $SKIP_HFSUTILS = false -a ! -d hfsutils ]; then MISSING=true; fi
 
 	if [ $MISSING != false ]; then
 		echo "Not all third-party components have been built yet, ignoring --skip-thirdparty."
@@ -312,7 +312,7 @@ if [ $SKIP_THIRDPARTY != true ]; then
 	unset LDFLAGS
 
 	if [ $SKIP_HFSUTILS != false ]; then
-		# Build hfsutil
+		# Build hfsutils
 		mkdir -p $PREFIX/lib
 		mkdir -p $PREFIX/share/man/man1
 		mkdir -p hfsutils


### PR DESCRIPTION
I've been working on putting together a Homebrew formula in my own tap to make installing Retro68 simple, and due to the nature of extracting classic disk images like MPW-GM on a modern Mac, I've ended up needing to depend on `hfsutils` to prep the libraries. This then means that the Homebrew formula of Retro68 won't successfully install because Homebrew already sees the `hfsutils` programs in the place it's expecting to put Retro68's copies.

This patch adds a `--skip-hfsutils` flag to build-toolchain.bash, which skips only the build of hfsutils. This way we can just use the Homebrew-provided version (which is identical anyway) and Retro68 no longer conflicts with it.

I've already been building Retro68 on my machine with this patch, so I know it builds at least once, but I'm not 100% sure I've added the right conditional to rebuild checks, so feedback is very welcome.

Thanks!