### PR TITLE
Remove unused ARCHS variable

### DIFF
--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -113,15 +113,6 @@ for ARG in $*; do
 	esac
 done
 
-ARCHS=""
-if [ $BUILD_68K != false ]; then
-	ARCHS="$ARCHS m68k"
-fi
-if [ $BUILD_PPC != false ]; then
-	ARCHS="$ARCHS powerpc"
-fi
-
-
 ##################### Sanity checks
 
 if [ `pwd -P` == "$SRC" ]; then


### PR DESCRIPTION
Unless I'm missing something, the `ARCHS` variable is no longer used in this script so it could be removed.