### PR TITLE
32-bit build fixes

### DIFF
--- a/libelf/src/elf_getaroff.c
+++ b/libelf/src/elf_getaroff.c
@@ -38,7 +38,7 @@
 #include "libelfP.h"
 
 
-off_t
+int64_t
 elf_getaroff (Elf *elf)
 {
   /* Be gratious, the specs demand it.  */

--- a/libelf/src/elf_getbase.c
+++ b/libelf/src/elf_getbase.c
@@ -37,7 +37,7 @@
 #include "libelfP.h"
 
 
-off_t
+int64_t
 elf_getbase (Elf *elf)
 {
   return elf == NULL ? (off_t) -1 : elf->start_offset;

--- a/libelf/src/elf_getdata_rawchunk.c
+++ b/libelf/src/elf_getdata_rawchunk.c
@@ -41,7 +41,7 @@
 #include "common.h"
 
 Elf_Data *
-elf_getdata_rawchunk (Elf *elf, off_t offset, size_t size, Elf_Type type)
+elf_getdata_rawchunk (Elf *elf, int64_t offset, size_t size, Elf_Type type)
 {
   if (unlikely (elf == NULL))
     return NULL;

--- a/libelf/src/elf_update.c
+++ b/libelf/src/elf_update.c
@@ -149,7 +149,7 @@ write_file (Elf *elf, off_t size, int change_bo, size_t shnum)
 }
 
 
-off_t
+int64_t
 elf_update (Elf *elf, Elf_Cmd cmd)
 {
   size_t shnum;


### PR DESCRIPTION
Fixes to make libelf build in 32-bit. Built PPC & 68K on Debian 4.19.98-1+deb10u1 and simple sanity tests on minivmac. Addresses https://github.com/autc04/Retro68/issues/119 (Option A for all).