### PR TITLE
fixes bug in build-toolchain when running on Power Mac

### DIFF
--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -204,7 +204,7 @@ if [ $SKIP_THIRDPARTY != true ]; then
 	if [ `uname` = Darwin ]; then
 			# present-day Mac users are likely to install dependencies
 			# via the homebrew package manager
-		if [ `uname -m` = arm64 ]; then
+		if [ "`uname -m`" = arm64 ]; then
 			export CPPFLAGS="-I/opt/homebrew/include"
 			export LDFLAGS="-L/opt/homebrew/lib"
 		else


### PR DESCRIPTION
Running on a Power Mac + Tiger system, `uname -m` returns "Power Mac".
Unless the result is quoted, it will get improperly split and the if
conditional breaks.