### PR TITLE
#include <sstream> in Rez/RezLexerNextToken.cc

### DIFF
--- a/Rez/RezLexerNextToken.cc
+++ b/Rez/RezLexerNextToken.cc
@@ -2,6 +2,7 @@
 #include "RezLexerWaveToken.h"
 #include "RezParser.generated.hh"
 #include <unordered_map>
+#include <sstream>
 
 #include <boost/regex.hpp>
 


### PR DESCRIPTION
Fixes bug building on a fresh install of macOS 11.3.1, boost 1.76.0, bison 3.7.6. I was getting the following error when compiling:

`Rez/RezLexerNextToken.cc:77:24: error: implicit instantiation of undefined template 'std::__1::basic_ostringstream<char>'
    std::ostringstream out;`

Evidently `sstream` was previously included in another header referenced by this file but now is not. I have added an `#include <sstream>` directive which allows the project to build.