### PR TITLE
Fix for Boost 1.79

### DIFF
--- a/LaunchAPPL/Client/SharedFile.cc
+++ b/LaunchAPPL/Client/SharedFile.cc
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <iostream>
 #include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
 
 namespace fs = boost::filesystem;
 namespace po = boost::program_options;


### PR DESCRIPTION
This is a quick fix for compiling with Boost 1.79, mentioned in issue #158.