### PR TITLE
don't try to upload PR builds to cachix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,12 +96,16 @@ jobs:
   - publish: CompiledSamples
     artifact: Samples ($(TARGET))
   - script: |
+      if [ -z "$CACHIX_AUTH_TOKEN" ]; then
+        echo "Token for cachix access not available, skipping."
+        exit
+      fi
       docker start nix -i <<EOF
-        export CACHIX_AUTH_TOKEN=$CACHIX_AUTH_TOKEN
-        cd src
-        nix-build -A ${TARGET}.retro68.samples | cachix push autc04
-        nix-shell -A ${TARGET} --command exit
-        nix-store -qR --include-outputs \$(nix-instantiate default.nix -A ${TARGET}) | cachix push autc04
+          export CACHIX_AUTH_TOKEN=$CACHIX_AUTH_TOKEN
+          cd src
+          nix-build -A ${TARGET}.retro68.samples | cachix push autc04
+          nix-shell -A ${TARGET} --command exit
+          nix-store -qR --include-outputs \$(nix-instantiate default.nix -A ${TARGET}) | cachix push autc04
       EOF
     displayName: Push to Cachix
     env:
@@ -138,6 +142,10 @@ jobs:
       nix-build -A $(TARGET).retro68.samples
     displayName: build
   - script: |
+      if [ -z "$CACHIX_AUTH_TOKEN" ]; then
+        echo "Token for cachix access not available, skipping."
+        exit
+      fi
       . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
       export CACHIX_AUTH_TOKEN=$CACHIX_AUTH_TOKEN
       nix-build -A $(TARGET).retro68.samples | cachix push autc04


### PR DESCRIPTION
Don't try to upload Pull Request build results to Cachix - i will fail because the token is not supplied to PR builds (for obvious security reasons)