### PR TITLE
Link to www.nixos.org is Github-relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ so you can also `cd` to one of these and run `make` separately if you've made ch
 Using Retro68 with Nix
 ----------------------
 
-If you are not using the [Nix Package Manager](www.nixos.org), please skip this section. But maybe you should be using it ;-).
+If you are not using the [Nix Package Manager](https://www.nixos.org), please skip this section. But maybe you should be using it ;-).
 
 Nix is a package manager that runs on Linux and macOS, and NixOS is a Linux distribution based on it.
 


### PR DESCRIPTION
This link to www.nixos.org incorrectly leads to https://github.com/autc04/Retro68/blob/master/www.nixos.org: https://github.com/autc04/Retro68/blob/8109463758f9c2aaaebfe9d00ddba235ed57b76a/README.md?plain=1#L155

The reason is the missing `https://` schema, so when Github renders the markdown, it treats the link as Github-relative. This PR fixes that.