### PR TITLE
MiniVMac.cc: Copy some extensions if present

### DIFF
--- a/LaunchAPPL/Client/MiniVMac.cc
+++ b/LaunchAPPL/Client/MiniVMac.cc
@@ -274,6 +274,24 @@ MiniVMacLauncher::MiniVMacLauncher(po::variables_map &options)
     if (usesAutQuit7)
     {
         CopySystemFile("Finder", true);
+        CopySystemFile("System 7.5 Update", false);
+        if(hfs_chdir(sysvol, "Extensions") != -1)
+        {
+            hfs_mkdir(vol, "Extensions");
+            if(hfs_chdir(vol, "Extensions") != -1)
+            {
+                CopySystemFile("Appearance Extension", false);
+                CopySystemFile("System 7 Tuner", false);
+                CopySystemFile("System Update", false);
+                hfs_chdir(vol, "::");
+            }
+            hfs_chdir(sysvol, "::");
+        }
+    }
+    else
+    {
+        CopySystemFile("32-Bit QuickDraw", false);
+        CopySystemFile("TrueType\xaa 1.0", false);
     }
 
     {


### PR DESCRIPTION
This is not a full fix for #171 because that would require recursive copying which is unfortunately not built into libhfs, much to everyone's annoyance. It's just a quick fix to copy some of the more essential extensions, if they're present:

On System 7.x:

* **System 7 Tuner** (for System 7.0.1), **System Update** (for System 7.1.x), and **System 7.5 Update** (for System 7.5.x) which fix various bugs
* **Appearance Extension**; if the user bothered to install it, they probably either want the sticky menus or are developing an app that uses it

On System 6.x and earlier:

* **32-Bit QuickDraw** and **TrueType™ 1.0**, again on the assumption that if the user installed them they care about them

It also serves as an example if a user needs to modify it to install some other extension or file they need.

Hardcoding the "Extensions" folder name is not correct since it will be different on many international OS versions (see also #172), for example on German Mac OS it should be "Systemerweiterungen." Reading the correct localized folder name out of the System file is probably possible but something that can wait until later. (After all, the existing code already hardcodes the "Startup Items" folder name.) Maybe the extension names themselves are localized too. The difficulty of handling that goes away if recursive copying of the whole system disk is implemented instead.