### PR TITLE
Azure: Update to macOS 11

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-11'
   timeoutInMinutes: 90
   steps:
   - checkout: self


### PR DESCRIPTION
The macOS 10.15 environment is scheduled for removal by December and is subject to periodic scheduled brownouts until then.

See https://github.com/actions/virtual-environments/issues/5583