### PR TITLE
MiniVMac.cc: Preserve attributes when copying

### DIFF
--- a/LaunchAPPL/Client/MiniVMac.cc
+++ b/LaunchAPPL/Client/MiniVMac.cc
@@ -460,6 +460,8 @@ void MiniVMacLauncher::CopySystemFile(const std::string &fn, bool required)
     hfs_setfork(out, 1);
     hfs_read(in, buffer.data(), fileent.u.file.rsize);
     hfs_write(out, buffer.data(), fileent.u.file.rsize);
+    fileent.fdflags &= ~HFS_FNDR_HASBEENINITED;
+    hfs_fsetattr(out, &fileent);
     hfs_close(in);
     hfs_close(out);
 }


### PR DESCRIPTION
When copying files from the system disk image to the new disk image, preserve all attributes (creation date, modification date, bundle bit, locked bit, etc.), except clear the inited bit so that the Finder chooses new icon positions, otherwise (under System 6 at least) the icons pile up on top of each other. Preserving the bundle bit in particular tells the Finder to look in the file for icon information when building the desktop database, without which the files all show generic icons in the Finder.