### PR TITLE
LaunchAPPL: Find libhfs header/library

### DIFF
--- a/LaunchAPPL/Client/CMakeLists.txt
+++ b/LaunchAPPL/Client/CMakeLists.txt
@@ -1,4 +1,6 @@
 find_package(Boost COMPONENTS filesystem program_options)
+find_path(HFS_INCLUDE_DIR NAMES hfs.h)
+find_library(HFS_LIBRARY NAMES hfs)
 
 set(LAUNCHMETHODS
     Executor.h Executor.cc
@@ -29,10 +31,9 @@ add_executable(LaunchAPPL
     Utilities.h Utilities.cc
 
     ${LAUNCHMETHODS})
-    
 
-target_include_directories(LaunchAPPL PRIVATE ${CMAKE_INSTALL_PREFIX}/include ${Boost_INCLUDE_DIR})
-target_link_libraries(LaunchAPPL ResourceFiles LaunchAPPLCommon ${Boost_LIBRARIES})
+target_include_directories(LaunchAPPL PRIVATE ${CMAKE_INSTALL_PREFIX}/include ${Boost_INCLUDE_DIR} ${HFS_INCLUDE_DIR})
+target_link_libraries(LaunchAPPL ResourceFiles LaunchAPPLCommon ${Boost_LIBRARIES} ${HFS_LIBRARY})
 
 if(APPLE)
     find_library(APPLICATIONSERVICES_FW ApplicationServices)


### PR DESCRIPTION
LaunchAPPL's MiniVMac.cc directly includes hfs.h and uses its library functions, but its CMakeLists.txt doesn't mention that, so when I try to build LaunchAPPL (with libhfs installed by MacPorts in /opt/local/{include,lib}) it fails:

```
LaunchAPPL/Client/MiniVMac.cc:8:10: fatal error: 'hfs.h' file not found
#include "hfs.h"
         ^~~~~~~
1 error generated.
```

This PR fixes it by copying the code to find libhfs from the ResourceFiles CMakeLists.txt (c8d627cdc4b33b33eadc228ab480a652cf70ad82).