### PR TITLE
Add Objective-C support

### DIFF
--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -237,7 +237,7 @@ if [ $SKIP_THIRDPARTY != true ]; then
 		cd gcc-build
 		export target_configargs="--disable-nls --enable-libstdcxx-dual-abi=no --disable-libstdcxx-verbose"
 		$SRC/gcc/configure --target=m68k-apple-macos --prefix=$PREFIX \
-				--enable-languages=c,c++ --with-arch=m68k --with-cpu=m68000 \
+				--enable-languages=c,c++,objc,obj-c++ --with-arch=m68k --with-cpu=m68000 \
 				--disable-libssp MAKEINFO=missing
 		# There seems to be a build failure in parallel builds; ignore any errors and try again without -j8.
 		make -j8 || make
@@ -280,7 +280,7 @@ if [ $SKIP_THIRDPARTY != true ]; then
 		cd gcc-build-ppc
 		export target_configargs="--disable-nls --enable-libstdcxx-dual-abi=no --disable-libstdcxx-verbose"
 		$SRC/gcc/configure --target=powerpc-apple-macos --prefix=$PREFIX \
-			--enable-languages=c,c++ --disable-libssp --disable-lto MAKEINFO=missing
+			--enable-languages=c,c++,objc,obj-c++ --disable-libssp --disable-lto MAKEINFO=missing
 		make -j8
 		make install
 		unset target_configargs

--- a/gcc/Makefile.in
+++ b/gcc/Makefile.in
@@ -1049,7 +1049,6 @@ configure-target:  \
     maybe-configure-target-libbacktrace \
     maybe-configure-target-libquadmath \
     maybe-configure-target-libgfortran \
-    maybe-configure-target-libobjc \
     maybe-configure-target-libgo \
     maybe-configure-target-libhsail-rt \
     maybe-configure-target-libphobos \
@@ -1212,7 +1211,6 @@ all-target: maybe-all-target-libgcc
 all-target: maybe-all-target-libbacktrace
 all-target: maybe-all-target-libquadmath
 all-target: maybe-all-target-libgfortran
-all-target: maybe-all-target-libobjc
 all-target: maybe-all-target-libgo
 all-target: maybe-all-target-libhsail-rt
 all-target: maybe-all-target-libphobos
@@ -1304,7 +1302,6 @@ info-target: maybe-info-target-libgcc
 info-target: maybe-info-target-libbacktrace
 info-target: maybe-info-target-libquadmath
 info-target: maybe-info-target-libgfortran
-info-target: maybe-info-target-libobjc
 info-target: maybe-info-target-libgo
 info-target: maybe-info-target-libhsail-rt
 info-target: maybe-info-target-libphobos
@@ -1389,7 +1386,6 @@ dvi-target: maybe-dvi-target-libgcc
 dvi-target: maybe-dvi-target-libbacktrace
 dvi-target: maybe-dvi-target-libquadmath
 dvi-target: maybe-dvi-target-libgfortran
-dvi-target: maybe-dvi-target-libobjc
 dvi-target: maybe-dvi-target-libgo
 dvi-target: maybe-dvi-target-libhsail-rt
 dvi-target: maybe-dvi-target-libphobos
@@ -1474,7 +1470,6 @@ pdf-target: maybe-pdf-target-libgcc
 pdf-target: maybe-pdf-target-libbacktrace
 pdf-target: maybe-pdf-target-libquadmath
 pdf-target: maybe-pdf-target-libgfortran
-pdf-target: maybe-pdf-target-libobjc
 pdf-target: maybe-pdf-target-libgo
 pdf-target: maybe-pdf-target-libhsail-rt
 pdf-target: maybe-pdf-target-libphobos
@@ -1559,7 +1554,6 @@ html-target: maybe-html-target-libgcc
 html-target: maybe-html-target-libbacktrace
 html-target: maybe-html-target-libquadmath
 html-target: maybe-html-target-libgfortran
-html-target: maybe-html-target-libobjc
 html-target: maybe-html-target-libgo
 html-target: maybe-html-target-libhsail-rt
 html-target: maybe-html-target-libphobos
@@ -1644,7 +1638,6 @@ TAGS-target: maybe-TAGS-target-libgcc
 TAGS-target: maybe-TAGS-target-libbacktrace
 TAGS-target: maybe-TAGS-target-libquadmath
 TAGS-target: maybe-TAGS-target-libgfortran
-TAGS-target: maybe-TAGS-target-libobjc
 TAGS-target: maybe-TAGS-target-libgo
 TAGS-target: maybe-TAGS-target-libhsail-rt
 TAGS-target: maybe-TAGS-target-libphobos
@@ -1729,7 +1722,6 @@ install-info-target: maybe-install-info-target-libgcc
 install-info-target: maybe-install-info-target-libbacktrace
 install-info-target: maybe-install-info-target-libquadmath
 install-info-target: maybe-install-info-target-libgfortran
-install-info-target: maybe-install-info-target-libobjc
 install-info-target: maybe-install-info-target-libgo
 install-info-target: maybe-install-info-target-libhsail-rt
 install-info-target: maybe-install-info-target-libphobos
@@ -1814,7 +1806,6 @@ install-pdf-target: maybe-install-pdf-target-libgcc
 install-pdf-target: maybe-install-pdf-target-libbacktrace
 install-pdf-target: maybe-install-pdf-target-libquadmath
 install-pdf-target: maybe-install-pdf-target-libgfortran
-install-pdf-target: maybe-install-pdf-target-libobjc
 install-pdf-target: maybe-install-pdf-target-libgo
 install-pdf-target: maybe-install-pdf-target-libhsail-rt
 install-pdf-target: maybe-install-pdf-target-libphobos
@@ -1899,7 +1890,6 @@ install-html-target: maybe-install-html-target-libgcc
 install-html-target: maybe-install-html-target-libbacktrace
 install-html-target: maybe-install-html-target-libquadmath
 install-html-target: maybe-install-html-target-libgfortran
-install-html-target: maybe-install-html-target-libobjc
 install-html-target: maybe-install-html-target-libgo
 install-html-target: maybe-install-html-target-libhsail-rt
 install-html-target: maybe-install-html-target-libphobos
@@ -1984,7 +1974,6 @@ installcheck-target: maybe-installcheck-target-libgcc
 installcheck-target: maybe-installcheck-target-libbacktrace
 installcheck-target: maybe-installcheck-target-libquadmath
 installcheck-target: maybe-installcheck-target-libgfortran
-installcheck-target: maybe-installcheck-target-libobjc
 installcheck-target: maybe-installcheck-target-libgo
 installcheck-target: maybe-installcheck-target-libhsail-rt
 installcheck-target: maybe-installcheck-target-libphobos
@@ -2069,7 +2058,6 @@ mostlyclean-target: maybe-mostlyclean-target-libgcc
 mostlyclean-target: maybe-mostlyclean-target-libbacktrace
 mostlyclean-target: maybe-mostlyclean-target-libquadmath
 mostlyclean-target: maybe-mostlyclean-target-libgfortran
-mostlyclean-target: maybe-mostlyclean-target-libobjc
 mostlyclean-target: maybe-mostlyclean-target-libgo
 mostlyclean-target: maybe-mostlyclean-target-libhsail-rt
 mostlyclean-target: maybe-mostlyclean-target-libphobos
@@ -2154,7 +2142,6 @@ clean-target: maybe-clean-target-libgcc
 clean-target: maybe-clean-target-libbacktrace
 clean-target: maybe-clean-target-libquadmath
 clean-target: maybe-clean-target-libgfortran
-clean-target: maybe-clean-target-libobjc
 clean-target: maybe-clean-target-libgo
 clean-target: maybe-clean-target-libhsail-rt
 clean-target: maybe-clean-target-libphobos
@@ -2239,7 +2226,6 @@ distclean-target: maybe-distclean-target-libgcc
 distclean-target: maybe-distclean-target-libbacktrace
 distclean-target: maybe-distclean-target-libquadmath
 distclean-target: maybe-distclean-target-libgfortran
-distclean-target: maybe-distclean-target-libobjc
 distclean-target: maybe-distclean-target-libgo
 distclean-target: maybe-distclean-target-libhsail-rt
 distclean-target: maybe-distclean-target-libphobos
@@ -2324,7 +2310,6 @@ maintainer-clean-target: maybe-maintainer-clean-target-libgcc
 maintainer-clean-target: maybe-maintainer-clean-target-libbacktrace
 maintainer-clean-target: maybe-maintainer-clean-target-libquadmath
 maintainer-clean-target: maybe-maintainer-clean-target-libgfortran
-maintainer-clean-target: maybe-maintainer-clean-target-libobjc
 maintainer-clean-target: maybe-maintainer-clean-target-libgo
 maintainer-clean-target: maybe-maintainer-clean-target-libhsail-rt
 maintainer-clean-target: maybe-maintainer-clean-target-libphobos
@@ -2465,7 +2450,6 @@ check-target:  \
     maybe-check-target-libbacktrace \
     maybe-check-target-libquadmath \
     maybe-check-target-libgfortran \
-    maybe-check-target-libobjc \
     maybe-check-target-libgo \
     maybe-check-target-libhsail-rt \
     maybe-check-target-libphobos \
@@ -2646,7 +2630,6 @@ install-target:  \
     maybe-install-target-libbacktrace \
     maybe-install-target-libquadmath \
     maybe-install-target-libgfortran \
-    maybe-install-target-libobjc \
     maybe-install-target-libgo \
     maybe-install-target-libhsail-rt \
     maybe-install-target-libphobos \
@@ -2751,7 +2734,6 @@ install-strip-target:  \
     maybe-install-strip-target-libbacktrace \
     maybe-install-strip-target-libquadmath \
     maybe-install-strip-target-libgfortran \
-    maybe-install-strip-target-libobjc \
     maybe-install-strip-target-libgo \
     maybe-install-strip-target-libhsail-rt \
     maybe-install-strip-target-libphobos \


### PR DESCRIPTION
This does not build libobjc, as it is broken in several ways. However, it doesn't matter, since libobjc is basically not used by anyone anyway and everybody uses a different runtime such as the ObjFW runtime.