### PR TITLE
ConvertObj: Fix typos in error messages

### DIFF
--- a/ConvertObj/ConvertObj.cc
+++ b/ConvertObj/ConvertObj.cc
@@ -301,14 +301,14 @@ int main(int argc, char* argv[])
 {
     if(argc != 2)
     {
-        std::cerr << "Usage: ConvertOBJ mpw.o > retro68.s\n";
+        std::cerr << "Usage: ConvertObj mpw.o > retro68.s\n";
         return 1;
     }
     std::ifstream in(argv[1]);
     if(!in)
     {
-        std::cerr << "Could not read imput file \"" << argv[1] << "\"\n";
-        std::cerr << "Usage: ConvertOBJ mpw.o > retro68.s\n";
+        std::cerr << "Could not read input file \"" << argv[1] << "\"\n";
+        std::cerr << "Usage: ConvertObj mpw.o > retro68.s\n";
         return 1;
     }
     


### PR DESCRIPTION
"ConvertObj" was mis-capitalized and "input" was misspelled.