### PR TITLE
Declare all C function parameters

### DIFF
--- a/AutomatedTests/Empty.c
+++ b/AutomatedTests/Empty.c
@@ -1,4 +1,4 @@
-int main()
+int main(void)
 {
     // Test: do things work well enough for us to get to main()?
     return 0;

--- a/AutomatedTests/File.c
+++ b/AutomatedTests/File.c
@@ -1,6 +1,6 @@
 #include "Test.h"
 
-int main()
+int main(void)
 {
     TEST_LOG_OK();
 }

--- a/AutomatedTests/Log.c
+++ b/AutomatedTests/Log.c
@@ -2,7 +2,7 @@
 
 char readWriteData[6] = "Three";
 
-int main()
+int main(void)
 {
         // constant initialized data
     TEST_LOG_SIZED("One",3);

--- a/AutomatedTests/PCRel32.c
+++ b/AutomatedTests/PCRel32.c
@@ -6,7 +6,7 @@ __attribute__((noinline)) static void* foo(size_t x)
     return malloc(x);  
 }
 
-int main()
+int main(void)
 {
     if(*(short*)&foo != 0x60FF)
     {

--- a/AutomatedTests/PascalTrap.c
+++ b/AutomatedTests/PascalTrap.c
@@ -1,12 +1,12 @@
 #include <FixMath.h>
 #include "Test.h"
 
-short calc()
+short calc(void)
 {
     return FixRound(FixRatio(42,5));
 }
 
-int main()
+int main(void)
 {
     if(calc() == 8)
         TEST_LOG_OK();

--- a/AutomatedTests/ReallyEmpty.c
+++ b/AutomatedTests/ReallyEmpty.c
@@ -1,4 +1,4 @@
-void _start()
+void _start(void)
 {
     // Test: do things work well enough for us to get to a startup function?
     // Note: this won't work for multisegment 68K apps, as the startup function will be in the wrong segment.

--- a/AutomatedTests/Segment1.c
+++ b/AutomatedTests/Segment1.c
@@ -5,8 +5,8 @@
 
 int variable;
 
-void Foo();
-void Bar();
+void Foo(void);
+void Bar(void);
 
 Boolean Test(Boolean unloadFoo, Boolean unloadBar, Boolean compact)
 {
@@ -36,7 +36,7 @@ Boolean Test(Boolean unloadFoo, Boolean unloadBar, Boolean compact)
     return true;
 }
 
-int main()
+int main(void)
 {
     Size grow, maxblock, maxblock2, freemem, freemem2;
 

--- a/AutomatedTests/Segment2.c
+++ b/AutomatedTests/Segment2.c
@@ -1,11 +1,11 @@
 extern int variable;
 #include <SegLoad.h>
-void Foo()
+void Foo(void)
 {
     variable *= 9;
 }
 
-void Bar()
+void Bar(void)
 {
     variable /= 9;
     variable *= 7;

--- a/AutomatedTests/StdIO.c
+++ b/AutomatedTests/StdIO.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-int main()
+int main(void)
 {
     FILE *f = fopen("out", "w");
     fprintf(f, "OK\n");

--- a/AutomatedTests/Timeout.c
+++ b/AutomatedTests/Timeout.c
@@ -1,6 +1,6 @@
 #include "Test.h"
 
-int main()
+int main(void)
 {
     TEST_LOG_SIZED("One",3);
     TEST_LOG_SIZED("Two",3);

--- a/AutomatedTests/ZeroInitialized.c
+++ b/AutomatedTests/ZeroInitialized.c
@@ -8,7 +8,7 @@ int commonSymbol;
 int zeroInited = 0;
 EventRecord e;
 
-int main()
+int main(void)
 {
     int i;
     if(commonSymbol)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED TRUE)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror=return-type -Wno-multichar")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror=return-type -Werror=strict-prototypes -Wno-multichar")
 
 enable_testing()
 

--- a/Samples/Dialog/dialog.c
+++ b/Samples/Dialog/dialog.c
@@ -42,7 +42,7 @@ pascal void ButtonFrameProc(DialogRef dlg, DialogItemIndex itemNo)
     FrameRoundRect(&box,16,16);
 }
 
-int main()
+int main(void)
 {
 #if !TARGET_API_MAC_CARBON
     InitGraf(&qd.thePort);

--- a/Samples/Launcher/Launcher.c
+++ b/Samples/Launcher/Launcher.c
@@ -26,7 +26,7 @@
 
 #include <string.h>
 
-void Explain()
+void Explain(void)
 {
     printf("*********************************************************\n");
     printf("This program is intended to make developing software\n");
@@ -41,7 +41,7 @@ void Explain()
     printf("*********************************************************\n");
 }
 
-void EjectOldDisk()
+void EjectOldDisk(void)
 {
     Handle h = GetResource('LNCH', 128);
     if(h)
@@ -55,7 +55,7 @@ void EjectOldDisk()
     }
 }
 
-int main()
+int main(void)
 {
     Explain();
     EjectOldDisk();

--- a/Samples/MPWTool/main.c
+++ b/Samples/MPWTool/main.c
@@ -48,12 +48,12 @@ struct MPWFile;
 
 struct fsysTable
 {
-    void (*quit)();
-    void (*access)();
+    void (*quit)(void);
+    void (*access)(void);
     void (*close)(struct MPWFile *);
     void (*read)(struct MPWFile *);
     void (*write)(struct MPWFile *);
-    void (*ioctl)();
+    void (*ioctl)(void);
 };
 
 struct devtable
@@ -101,7 +101,7 @@ struct pgminfo
 
 
 // Get MPW's magic struct
-struct pgminfo2 * getPgmInfo()
+struct pgminfo2 *getPgmInfo(void)
 {
     struct pgminfo *pgm0 = *(struct pgminfo**) 0x316;
     if(!pgm0)
@@ -132,7 +132,7 @@ void _exit(int status)
 const int procInfo = kCStackBased
     | STACK_ROUTINE_PARAMETER(1, kFourByteCode);
 
-int main()
+int main(int argc, char *argv[], char *envp[])
 {
     struct pgminfo2 *pgm = getPgmInfo();
     if(pgm)
@@ -152,19 +152,20 @@ int main()
 
 #if TARGET_CPU_PPC
 
-void __do_global_dtors();
+void __do_global_dtors(void);
 
-void __start()
+void __start(void)
 {
     if(setjmp(exit_buf))
-    ;
+        ;
     else
     {
         atexit(&__do_global_dtors);
         int result;
         {
             char *argv[2] = { "./a.out", NULL };
-            result = main(1, argv);
+            char *envp[1] = { NULL };
+            result = main(1, argv, envp);
         }
         exit(result);
     }
@@ -174,7 +175,7 @@ void *__dso_handle = &__dso_handle;
 
 #else
 
-void _start()
+void _start(void)
 {
     RETRO68_RELOCATE();
 
@@ -188,7 +189,8 @@ void _start()
         int result;
         {
             char *argv[2] = { "./a.out", NULL };
-            result = main(1, argv);
+            char *envp[1] = { NULL };
+            result = main(1, argv, envp);
         }
         exit(result);
     }

--- a/Samples/Raytracer/raytracer.c
+++ b/Samples/Raytracer/raytracer.c
@@ -157,7 +157,7 @@ float ray(int n, float x0, float y0, float z0, float dx, float dy, float dz)
         return v;
 }
 
-int main()
+int main(void)
 {
     WindowPtr win;
     

--- a/Samples/SharedLibrary/application.c
+++ b/Samples/SharedLibrary/application.c
@@ -23,7 +23,7 @@
 
 #include "library.h"
 
-int main()
+int main(void)
 {
         // wait until computer is turned on ;-)
     while(!is_computer_on())

--- a/Samples/SharedLibrary/library.c
+++ b/Samples/SharedLibrary/library.c
@@ -25,7 +25,7 @@
 #include "library.h"
 #include <Sound.h>
 
-void beep()
+void beep(void)
 {
     SysBeep(20);
 }
@@ -39,7 +39,7 @@ void beep()
  * Note that a function by this name was an actual, documented part
  * of the BeOS API.
  */
-Boolean is_computer_on()
+Boolean is_computer_on(void)
 {
     return true;
 }

--- a/Samples/SharedLibrary/library.h
+++ b/Samples/SharedLibrary/library.h
@@ -19,5 +19,5 @@
 
 #include <MacTypes.h>
 
-void beep();
-Boolean is_computer_on();
+void beep(void);
+Boolean is_computer_on(void);

--- a/Samples/SystemExtension/SystemExtension.c
+++ b/Samples/SystemExtension/SystemExtension.c
@@ -2,7 +2,7 @@
 #include "ShowInitIcon.h"
 #include "Retro68Runtime.h"
 
-void _start()
+void _start(void)
 {
     RETRO68_RELOCATE();
     Retro68CallConstructors();

--- a/Samples/WDEF/wdefshell.c
+++ b/Samples/WDEF/wdefshell.c
@@ -64,7 +64,7 @@ void MakeNewWindow(ConstStr255Param title, short procID)
     OffsetRect(&nextWindowRect, 15, 15);
 }
 
-void InitCustomWDEF()
+void InitCustomWDEF(void)
 {
 /* The 10-byte code resource stub trick.
  *
@@ -91,7 +91,7 @@ void InitCustomWDEF()
     // with custom WDEFs.
 }
 
-void ShowAboutBox()
+void ShowAboutBox(void)
 {
     WindowRef w = GetNewWindow(128, NULL, (WindowPtr) - 1);
     MoveWindow(w,
@@ -116,7 +116,7 @@ void ShowAboutBox()
     DisposeWindow(w);
 }
 
-void UpdateMenus()
+void UpdateMenus(void)
 {
     MenuRef m = GetMenu(kMenuFile);
     WindowRef w = FrontWindow();
@@ -234,7 +234,7 @@ void DoUpdate(WindowRef w)
     EndUpdate(w);
 }
 
-int main()
+int main(void)
 {
     InitGraf(&qd.thePort);
     InitFonts();

--- a/TestApps/EmptyTest.c
+++ b/TestApps/EmptyTest.c
@@ -1,4 +1,4 @@
-int main()
+int main(void)
 {
     return 0;
 }

--- a/libretro/MultiSegApp.c
+++ b/libretro/MultiSegApp.c
@@ -14,7 +14,7 @@ static UniversalProcPtr OriginalExitToShell;
 static UniversalProcPtr OriginalLaunch;
 static UniversalProcPtr OriginalChain;
 
-extern pascal void PatchedLoadSeg();
+extern pascal void PatchedLoadSeg(void);
 
 typedef union JTEntry
 {
@@ -171,10 +171,10 @@ static pascal void PatchedUnloadSeg(Ptr ptr)
     HPurge(CODE);
 }
 
-static void InstallPatches();
-static void UninstallPatches();
+static void InstallPatches(void);
+static void UninstallPatches(void);
 
-static pascal void PatchedExitToShell()
+static pascal void PatchedExitToShell(void)
 {
     UninstallPatches();
     ExitToShell();
@@ -204,7 +204,7 @@ static OSErr PatchedChain(void *p)
     return err;
 }
 
-static void InstallPatches()
+static void InstallPatches(void)
 {
     SetToolTrapAddress((UniversalProcPtr)&PatchedLoadSeg, _LoadSeg);
     SetToolTrapAddress((UniversalProcPtr)&PatchedUnloadSeg, _UnLoadSeg);
@@ -213,7 +213,7 @@ static void InstallPatches()
     SetToolTrapAddress((UniversalProcPtr)&PatchedChain, _Chain);
 }
 
-static void UninstallPatches()
+static void UninstallPatches(void)
 {
     SetToolTrapAddress((UniversalProcPtr)OriginalLoadSeg, _LoadSeg);
     SetToolTrapAddress((UniversalProcPtr)OriginalUnloadSeg, _UnLoadSeg);
@@ -226,7 +226,7 @@ static void UninstallPatches()
 // section boundaries
 extern uint8_t _stext, _etext, _sdata, _edata, _sbss[], _ebss;
 
-void Retro68InitMultisegApp()
+void Retro68InitMultisegApp(void)
 {
     uint8_t * a5 = (uint8_t*) StripAddressCompat((void*)SetCurrentA5());
 

--- a/libretro/Retro68Runtime.h
+++ b/libretro/Retro68Runtime.h
@@ -62,11 +62,11 @@
         (*(typeof(&FUN)) ((char*)(&FUN) + displacement)) ARGS;    \
     } while(0)
 
-void Retro68Relocate();
-void Retro68CallConstructors();
-void Retro68CallDestructors();
-void Retro68FreeGlobals();
-void Retro68InitMultisegApp();
+void Retro68Relocate(void);
+void Retro68CallConstructors(void);
+void Retro68CallDestructors(void);
+void Retro68FreeGlobals(void);
+void Retro68InitMultisegApp(void);
 void Retro68ApplyRelocations(uint8_t *base, uint32_t size, void *relocations, uint32_t displacements[]);
 
 #define RETRO68_RELOCATE() RETRO68_CALL_UNRELOCATED(Retro68Relocate,())

--- a/libretro/malloc.c
+++ b/libretro/malloc.c
@@ -29,7 +29,7 @@
 #include <string.h>
 #include <MacMemory.h>
 
-void referenceMyMalloc() {}
+void referenceMyMalloc(void) {}
 
 void *_malloc_r(struct _reent *reent_ptr, size_t sz)
 {

--- a/libretro/ppcstart.c
+++ b/libretro/ppcstart.c
@@ -28,9 +28,9 @@
 
 int main(int argc, char* argv[]);
 
-void __do_global_dtors();
+void __do_global_dtors(void);
 
-void __start()
+void __start(void)
 {
     int result;
 

--- a/libretro/start.c
+++ b/libretro/start.c
@@ -28,7 +28,7 @@
 
 int main(int argc, char* argv[]);
 
-void _start()
+void _start(void)
 {
     RETRO68_RELOCATE();
     atexit(&Retro68CallDestructors);


### PR DESCRIPTION
Specify parameters for all C functions. Not specifying parameters is the same as specifying "void" in C++ and in C23 and later but that's not the case in C prior to C23.

Compile C files with the same warnings as C++ files, additionally making the strict prototypes warning an error to catch such problems in the future. This commit isn't intended to address all the other warnings now being emitted.