### PR TITLE
Use global nixpkgs to allow immutable builds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@ in { system ? builtins.currentSystem, nixpkgs ? sources.nixpkgs, ... }:
 let
   retroPlatforms = import nix/platforms.nix;
 
-  lib = ((import nixpkgs) { }).lib;
+  lib = ((import nixpkgs) { inherit system; }).lib;
 
   multiversal_src = if builtins.pathExists ./multiversal/make-multiverse.rb then
     ./multiversal

--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@ in { system ? builtins.currentSystem, nixpkgs ? sources.nixpkgs, ... }:
 let
   retroPlatforms = import nix/platforms.nix;
 
-  lib = ((import <nixpkgs>) { }).lib;
+  lib = ((import nixpkgs) { }).lib;
 
   multiversal_src = if builtins.pathExists ./multiversal/make-multiverse.rb then
     ./multiversal


### PR DESCRIPTION
This allows Retro68 to be built as a flake, or imported into a flake, reducing impurity in the build process and improving reproducibility.