### PR TITLE
Retro68: improve Docker support to enable builds with Universal interfaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,19 @@ RUN mkdir /Retro68-build && \
 # Release image
 FROM base AS release
 
+ENV INTERFACES=multiversal
+
 COPY --from=build \
     /Retro68/interfaces-and-libraries.sh \
     /Retro68/prepare-headers.sh \
     /Retro68/prepare-rincludes.sh \
+    /Retro68/install-universal-interfaces.sh \
+    /Retro68/docker-entrypoint.sh \
     /Retro68-build/bin/
 
 COPY --from=build /Retro68-build/toolchain /Retro68-build/toolchain
 
 LABEL org.opencontainers.image.source https://github.com/autc04/Retro68
+
+CMD [ "/bin/bash" ]
+ENTRYPOINT [ "/Retro68-build/bin/docker-entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         cmake libgmp-dev libmpfr-dev libmpc-dev \
         libboost-all-dev bison texinfo \
-        ruby flex curl g++ git
+        ruby flex curl g++ git macutils
 
 # Add toolchain to default PATH
 ENV PATH=/Retro68-build/toolchain/bin:$PATH
@@ -19,10 +19,17 @@ FROM base AS build
 ADD . /Retro68
 
 RUN mkdir /Retro68-build && \
+    mkdir /Retro68-build/bin && \
     bash -c "cd /Retro68-build && bash /Retro68/build-toolchain.bash"
 
 # Release image
 FROM base AS release
+
+COPY --from=build \
+    /Retro68/interfaces-and-libraries.sh \
+    /Retro68/prepare-headers.sh \
+    /Retro68/prepare-rincludes.sh \
+    /Retro68-build/bin/
 
 COPY --from=build /Retro68-build/toolchain /Retro68-build/toolchain
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+
+TMPDIR=/tmp
+BUILDDIR=/Retro68-build
+
+if [[ $INTERFACES == "universal" ]];
+then
+    # If the universal RIncludes directory is empty, download and install the universal headers
+    if [ ! "$(ls -A $BUILDDIR/toolchain/universal/RIncludes 2> /dev/null)" ]; then
+        # If INTERFACESFILE is empty, exit
+        if [[ -z $INTERFACESFILE ]];
+        then
+            echo -n "Universal interfaces not present, please specify the location of a suitable "
+            echo "MacBinary DiskCopy image using the INTERFACESFILE environment variable."
+            exit 1
+        fi
+
+        BASEINTERFACESFILE=`basename $INTERFACESFILE`
+
+        # If INTERFACESFILE is a URL, download it first to TMPDIR. Otherwise assume the file is
+        # already present and copy it to TMPDIR for installation
+        if [[ $INTERFACESFILE == http* ]];
+        then
+            echo "Downloading Universal interfaces from MacBinary DiskCopy image $BASEINTERFACESFILE..."
+            curl -s $INTERFACESFILE -o $TMPDIR/$BASEINTERFACESFILE
+            echo "done"
+        else
+            if [[ -z $INTERFACESFILE ]];
+            then
+                echo "Unable to locate universal interfaces file $INTERFACESFILE"
+                exit 1
+            else
+                echo "Using Universal intefaces from MacBinary Diskcopy image $BASEINTERFACESFILE"
+                cp $INTERFACESFILE $TMPDIR/$BASEINTERFACESFILE
+            fi
+        fi
+
+        # Extract the file
+        $BUILDDIR/bin/install-universal-interfaces.sh $TMPDIR $BASEINTERFACESFILE
+
+        # Switch to universal
+        echo "Linking Universal interfaces..."
+        $BUILDDIR/bin/interfaces-and-libraries.sh $BUILDDIR/toolchain $TMPDIR/InterfacesAndLibraries
+        echo "done"
+    else
+        echo "Linking Universal interfaces..."
+
+        # Link to existing universal interfaces
+        PREFIX=$BUILDDIR/toolchain
+        . "$BUILDDIR/bin/interfaces-and-libraries.sh"
+        BUILD_68K=true
+        BUILD_PPC=true
+
+        unlinkInterfacesAndLibraries
+        linkInterfacesAndLibraries "universal"
+        echo "done"
+    fi
+else
+    echo "Using multiversal interfaces"
+fi
+
+# Execute command
+exec "$@"

--- a/install-universal-interfaces.sh
+++ b/install-universal-interfaces.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+#
+# install-universal-interfaces.sh
+#
+# Optionally download and attempt to install the universal interfaces from
+# a Macbinary disk image containing the Interfaces&Libraries directory
+#
+# Usage:
+#    install-universal-interfaces.sh <tempdir> <filename>
+#
+# Decompress the Macbinary image at <tempdir>/<filename> into
+# <tempdir>/InterfacesAndLibraries in the correct format for
+# interfaces-and-libraries.sh.
+#
+
+set -e
+
+TMPDIR=$1
+FILENAME=$2
+
+if [[ ! -f $TMPDIR/$FILENAME ]];
+then
+    echo "$TMPDIR/$FILENAME not found"
+    exit 1
+fi
+
+echo "Decompressing $FILENAME..."
+ConvertDiskImage $TMPDIR/$FILENAME $TMPDIR/$FILENAME.img
+echo "Decompression complete"
+
+# Copy over Interfaces&Libraries files
+echo "Copying Interfaces&Libraries files..."
+hmount $TMPDIR/$FILENAME.img
+
+# Find Interfaces&Libraries directory, get recursive directory listing
+HFSINTERFACESANDLIBSDIR=`hls -R | grep 'Interfaces&Libraries:$'`
+IFS="$(printf '\n')"
+echo "Found Interfaces&Libraries at $HFSINTERFACESANDLIBSDIR"
+FILES=`hls -FR1 $HFSINTERFACESANDLIBSDIR`
+
+UNIXINTERFACESANDLIBSDIR=$TMPDIR/InterfacesAndLibraries
+mkdir -p $UNIXINTERFACESANDLIBSDIR
+
+# Parse results: first line is the HFS path, following lines contain one file
+# per line terminated by an empty line
+while IFS= read -r LINE; do
+    if [[ $LINE == :* ]];
+    then
+       # If it starts with : then it is a HFS path
+       HFSPATH=$LINE
+       UNIXRELPATH=$(echo "$HFSPATH" | sed "s#$HFSINTERFACESANDLIBSDIR##g" | sed "s#:#/"#g)
+       UNIXPATH="$UNIXINTERFACESANDLIBSDIR/$UNIXRELPATH"
+
+       # Make UNIX directory
+       mkdir -p $UNIXPATH
+    else
+       # If it ends with : it is a directory so ignore (we will find it during the descent)
+       if [[ ! $LINE == *: ]];
+       then
+           # If it isn't empty, it must be a filename
+           if [[ ! -z $LINE ]];
+           then
+               HFSFULLPATH="$HFSPATH$LINE"
+               UNIXFULLPATH="$UNIXPATH$LINE"
+
+               echo "Copying $HFSFULLPATH to $UNIXFULLPATH"
+
+               # PPC libraries need a resource fork, but the code in
+               # interfaces-and-libraries.sh doesn't correctly detect InterfaceLib in
+               # Macbinary format. Work around this for now by using Basilisk II format
+               # which can be parsed by ResourceFile and still allows the filename
+               # detection logic to work.
+               if [[ $HFSPATH == *SharedLibraries: ]];
+               then
+                   if [[ ! -d $UNIXPATH.rsrc ]];
+                   then
+                       mkdir $UNIXPATH.rsrc
+                   fi
+
+                   # First copy as Macbinary
+                   hcopy -m $HFSFULLPATH $UNIXFULLPATH.bin
+
+                   # Extract data fork using normal name
+                   bash -c "cd $UNIXPATH && macunpack -d $UNIXFULLPATH.bin && mv $UNIXFULLPATH.data $UNIXFULLPATH"
+
+                   # Extract resource fork into .rsrc directory
+                   bash -c "cd $UNIXPATH && macunpack -r $UNIXFULLPATH.bin && mv $UNIXFULLPATH.rsrc $UNIXPATH.rsrc/$LINE"
+
+                   # Delete original Macbinary
+                   rm -rf $UNIXFULLPATH.bin
+               else
+                   hcopy -r $HFSFULLPATH $UNIXFULLPATH
+               fi
+           fi
+       fi
+    fi
+done <<< "$FILES"
+
+# Unmount image
+humount


### PR DESCRIPTION
Depends on: https://github.com/autc04/Retro68/pull/193

This PR follows up on my previous work at https://github.com/autc04/Retro68/pull/193 to generate a Docker image for Retro68, and adds support for builds with Universal interfaces. The motivation behind this is to provide the infrastructure required to allow CI builds from source for QEMU Mac Drivers (both 68K and PPC) which is a requirement for if binaries are to be distributed within QEMU itself.

As noted in the current README.md file, there is concern over the distribution of the MPW interfaces. The solution provided in this series is to provide a mechanism to dynamically generate the Retro68 headers from a `MPW-GM.img.bin` MacBinary DiskImage provided as either a file on the host or a remote URL. If the Universal interfaces are requested on startup by setting `INTERFACESFILE=universal` then the container startup sequence in `entrypoint.sh` looks like this:

- If the `INTERFACESFILE` variable is set to a URL, download it from the URL into the container
- Invoke ConvertDiskImage to decompress the DiskCopy image so it is usable by hfsutils
- Locate the `Interfaces&Libraries` folder within the image, and extract its contents
- Invoke the functions from `interfaces-and-libraries.sh` to link the Universal interfaces so that they are used instead of the in-built multiversal interfaces

The startup logic checks to see if the `universal/RIncludes` directory is empty on startup, and if so goes directly to linking the Universal interfaces to allow use of local caching without having to re-download the `MPW-GM.img.bin` file each time.

Finally this series updates README.md (see https://github.com/mcayland/Retro68/tree/feature/docker-build-universal#using-retro68-with-docker) to add a new section "Using Retro68 with Docker" giving examples showing how to perform multiversal or universal builds, both with or without caching.
