### PR TITLE
Nix Flakes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/README.md
+++ b/README.md
@@ -155,37 +155,39 @@ Using Retro68 with Nix
 If you are not using the [Nix Package Manager](https://www.nixos.org), please skip this section. But maybe you should be using it ;-).
 
 Nix is a package manager that runs on Linux and macOS, and NixOS is a Linux distribution based on it.
+Try the [Determinate Nix Installer](https://install.determinate.systems/) for the best installation experience.
 
-If you've got `nix` installed, after downloading Retro68, you can run
+[TODO: docs on using the binary cache to avoid builds]
 
-    nix-shell
+Once you've got `nix` installed, and without checking out the Retro68 repository, you can run
+
+    nix develop github:autc04/Retro68#m68k
 
 from the Retro68 directory to get a shell with the compiler tools targeting
 68K Macs available in the path, and `CC` and other environment variables already
 set up for you. You can then `cd` to one of the example directories or to your
 own project and use `cmake` to build it.
 
-You can use the `nix-shell` command to invoke various useful shell environments:
+Likewise, use
 
-| Command                             | What                                         |
-|-------------------------------------|----------------------------------------------|
-| `nix-shell`                         | 68K development environment                  |
-| `nix-shell -A m68k`                 | 68K development environment                  |
-| `nix-shell -A powerpc`              | PowerPC development environment              |
-| `nix-shell -A retro68.monolithic`   | Shell for running `build-toolchain.bash`     |
+    nix develop github:autc04/Retro68#powerpc
 
-You can also use the `nix-build` command to build packages. As always with `nix`,
+... to get an environment targeting PowerPC Macs.
+
+If you have a local checkout of Retro68, you can replace `github:autc04/Retro68` by the path
+to that local checkout, e.g., run `nix develop .#m68k` from inside the Retro68 directory.
+
+You can also use the `nix build` command to build packages. As always with `nix`,
 the result will be somewhere in a subdirectory of `/nix/store`, with a symlink
-named `result` placed in your Retro68 directory.
+named `result` placed in the directory where you invoked the command.
 
-| Command                                | What                                         |
-|----------------------------------------|----------------------------------------------|
-| `nix-build -A m68k.retro68.samples`    | Sample programs for 68K                      |
-| `nix-build -A powerpc.retro68.samples` | Sample programs for PowerPC                  |
-| `nix-build -A retro68.monolithic`      | Result of `build-toolchain.bash --no-carbon` |
-| `nix-build -A m68k.zlib`               | zlib library, cross-compiled for 68K Macs    |
-| `nix-build -A m68k.`*packagename*      | cross-compile *packagename* to 68K           |
-| `nix-build -A powerpc.`*packagename*   | cross-compile *packagename* to PowerPC       |
+| Command                                                            | What                                      |
+|--------------------------------------------------------------------|-------------------------------------------|
+| `nix build github:autc04/Retro68#samples-m68k`                     | Sample programs for 68K                   |
+| `nix build github:autc04/Retro68#samples-powerpc`                  | Sample programs for PowerPC               |
+| `nix build github:autc04/Retro68#pkgsCross.m68k.zlib`              | zlib library, cross-compiled for 68K Macs |
+| `nix build github:autc04/Retro68#pkgsCross.m68k.`*packagename*     | cross-compile *packagename* to 68K        |
+| `nnix build github:autc04/Retro68#pkgsCross.powerpc.`*packagename* | cross-compile *packagename* to PowerPC    |
 
 You can attempt to cross-compile *any* package from the `nixpkgs` collection. Unless the
 package contains a very portable library, the command will of course fail. Please don't

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,6 @@ jobs:
         TARGET: powerpc
       Carbon:
         TARGET: carbon
-    maxParallel: 2
   pool:
     vmImage: 'ubuntu-latest'
   steps:
@@ -131,7 +130,6 @@ jobs:
         TARGET: powerpc
       Carbon:
         TARGET: carbon
-    maxParallel: 2
   pool:
     vmImage: 'macOS-latest'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,84 +3,84 @@ trigger:
 
 jobs:
 
-#- job: Linux
-#  pool:
-#    vmImage: 'ubuntu-latest'
-#  timeoutInMinutes: 90
-#  variables:
-#  - group: Tokens  
-#  steps:
-#  - checkout: self
-#    submodules: true
-#
-#  - task: Docker@2
-#    inputs:
-#      command: build
-#      repository: ghcr.io/autc04/retro68-build
-#      tags: latest
-#      arguments: --target build
-#    displayName: 'Build'
-#  - task: Docker@2
-#    inputs:
-#      command: build
-#      repository: ghcr.io/autc04/retro68
-#      tags: latest
-#      arguments: --target release
-#    displayName: 'Build release'
-#  - script: |
-#      docker run --name retro68-build --rm -i -d ghcr.io/autc04/retro68-build:latest
-#      docker exec -i retro68-build /bin/bash <<"EOF"
-#        cd /Retro68-build
-#        curl -L -O https://github.com/autc04/executor/releases/download/v0.1.0/Executor2000-0.1.0-Linux.tar.bz2
-#        tar xfvj Executor2000-0.1.0-Linux.tar.bz2 Executor2000-0.1.0-Linux/bin/executor-headless
-#        echo "executor-path=`pwd`/Executor2000-0.1.0-Linux/bin/executor-headless" > ~/.LaunchAPPL.cfg
-#        echo "emulator=executor" >> ~/.LaunchAPPL.cfg
-#        ctest --no-compress-output -T test -E Carbon || true
-#      EOF
-#      mkdir build && docker cp retro68-build:/Retro68-build/Testing build
-#      docker stop retro68-build
-#    displayName: Run Tests using Executor 2000
-#  - task: PublishTestResults@2
-#    inputs:
-#      testResultsFormat: 'CTest'
-#      testResultsFiles: build/Testing/**/*.xml
-#      buildPlatform: 'x86_64-linux'
-#  - script: |
-#      docker login ghcr.io/autc04 -u autc04 -p $GHCR_TOKEN
-#      docker push ghcr.io/autc04/retro68
-#    env:
-#      GHCR_TOKEN: $(GHCR_TOKEN)
-#    displayName: 'Push release to GHCR'
-#    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-#
-#- job: macOS
-#  pool:
-#    vmImage: 'macOS-11'
-#  timeoutInMinutes: 90
-#  steps:
-#  - checkout: self
-#    submodules: true
-#  - script: |
-#      brew install boost cmake gmp mpfr libmpc bison
-#    displayName: 'Brew prerequisites'
-#  - script: |
-#      mkdir build
-#      cd build
-#      ../build-toolchain.bash
-#    displayName: Build
-#  - script: |
-#      cd build
-#      curl -L -O https://github.com/autc04/executor/releases/download/v0.1.0/Executor2000-0.1.0-Darwin.tar.bz2
-#      tar xfvj Executor2000-0.1.0-Darwin.tar.bz2 Executor2000-0.1.0-Darwin/bin/executor-headless
-#      echo "executor-path=`pwd`/Executor2000-0.1.0-Darwin/bin/executor-headless" > ~/.LaunchAPPL.cfg
-#      echo "emulator=executor" >> ~/.LaunchAPPL.cfg
-#      ctest --no-compress-output -T test -E Carbon || true
-#    displayName: Run Tests using Executor 2000
-#  - task: PublishTestResults@2
-#    inputs:
-#      testResultsFormat: 'CTest'
-#      testResultsFiles: build/Testing/**/*.xml
-#      buildPlatform: 'x86_64-macos'
+- job: Linux
+  pool:
+    vmImage: 'ubuntu-latest'
+  timeoutInMinutes: 90
+  variables:
+  - group: Tokens  
+  steps:
+  - checkout: self
+    submodules: true
+
+  - task: Docker@2
+    inputs:
+      command: build
+      repository: ghcr.io/autc04/retro68-build
+      tags: latest
+      arguments: --target build
+    displayName: 'Build'
+  - task: Docker@2
+    inputs:
+      command: build
+      repository: ghcr.io/autc04/retro68
+      tags: latest
+      arguments: --target release
+    displayName: 'Build release'
+  - script: |
+      docker run --name retro68-build --rm -i -d ghcr.io/autc04/retro68-build:latest
+      docker exec -i retro68-build /bin/bash <<"EOF"
+        cd /Retro68-build
+        curl -L -O https://github.com/autc04/executor/releases/download/v0.1.0/Executor2000-0.1.0-Linux.tar.bz2
+        tar xfvj Executor2000-0.1.0-Linux.tar.bz2 Executor2000-0.1.0-Linux/bin/executor-headless
+        echo "executor-path=`pwd`/Executor2000-0.1.0-Linux/bin/executor-headless" > ~/.LaunchAPPL.cfg
+        echo "emulator=executor" >> ~/.LaunchAPPL.cfg
+        ctest --no-compress-output -T test -E Carbon || true
+      EOF
+      mkdir build && docker cp retro68-build:/Retro68-build/Testing build
+      docker stop retro68-build
+    displayName: Run Tests using Executor 2000
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'CTest'
+      testResultsFiles: build/Testing/**/*.xml
+      buildPlatform: 'x86_64-linux'
+  - script: |
+      docker login ghcr.io/autc04 -u autc04 -p $GHCR_TOKEN
+      docker push ghcr.io/autc04/retro68
+    env:
+      GHCR_TOKEN: $(GHCR_TOKEN)
+    displayName: 'Push release to GHCR'
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+
+- job: macOS
+  pool:
+    vmImage: 'macOS-11'
+  timeoutInMinutes: 90
+  steps:
+  - checkout: self
+    submodules: true
+  - script: |
+      brew install boost cmake gmp mpfr libmpc bison
+    displayName: 'Brew prerequisites'
+  - script: |
+      mkdir build
+      cd build
+      ../build-toolchain.bash
+    displayName: Build
+  - script: |
+      cd build
+      curl -L -O https://github.com/autc04/executor/releases/download/v0.1.0/Executor2000-0.1.0-Darwin.tar.bz2
+      tar xfvj Executor2000-0.1.0-Darwin.tar.bz2 Executor2000-0.1.0-Darwin/bin/executor-headless
+      echo "executor-path=`pwd`/Executor2000-0.1.0-Darwin/bin/executor-headless" > ~/.LaunchAPPL.cfg
+      echo "emulator=executor" >> ~/.LaunchAPPL.cfg
+      ctest --no-compress-output -T test -E Carbon || true
+    displayName: Run Tests using Executor 2000
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'CTest'
+      testResultsFiles: build/Testing/**/*.xml
+      buildPlatform: 'x86_64-macos'
 
 - job: NixLinux
   strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,7 +109,7 @@ jobs:
   - script: |
       . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
       nix develop .#${TARGET} --profile dev-profile -c true
-      nix build .#samples-${TARGET} --out-link=CompiledSamples
+      nix build .#samples-${TARGET} --out-link CompiledSamples
     displayName: Build
   - publish: CompiledSamples
     artifact: Samples ($(TARGET))
@@ -149,7 +149,7 @@ jobs:
   - script: |
       . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
       nix develop .#${TARGET} --profile dev-profile -c true
-      nix build .#samples-${TARGET} --out-link=CompiledSamples
+      nix build .#samples-${TARGET} --out-link CompiledSamples
     displayName: Build
   - publish: CompiledSamples
     artifact: Samples ($(TARGET))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,7 +93,7 @@ jobs:
         TARGET: carbon
     maxParallel: 2
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: 'ubuntu-latest'
   steps:
   - script: |
       curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
@@ -133,7 +133,7 @@ jobs:
         TARGET: carbon
     maxParallel: 2
   pool:
-    vmImage: 'macOS-11'
+    vmImage: 'macOS-latest'
   steps:
   - script: |
       curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
@@ -151,8 +151,6 @@ jobs:
       nix develop .#${TARGET} --profile dev-profile -c true
       nix build .#samples-${TARGET} --out-link CompiledSamples
     displayName: Build
-  - publish: CompiledSamples
-    artifact: Samples ($(TARGET))
   - script: |
       . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
       export CACHIX_AUTH_TOKEN=$(CACHIX_AUTH_TOKEN)
@@ -160,6 +158,3 @@ jobs:
       cachix push autc04 CompiledSamples
     displayName: Push to Cachix
     condition: and(succeeded(), ne(variables['CACHIX_AUTH_TOKEN'], ''))
-
-  #export NIX_EXTRA_CONF="trusted-users = root runner"
-      #. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,8 +95,6 @@ jobs:
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
-  - checkout: self
-    submodules: false
   - script: |
       curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
     displayName: Install Nix
@@ -104,6 +102,8 @@ jobs:
       nix-env -iA cachix -f https://cachix.org/api/v1/install
       cachix use autc04
     displayName: Setup Cachix
+  - checkout: self
+    submodules: false
   - script: |
       nix develop .#${TARGET} --profile dev-profile -c true
       nix build .#samples-${TARGET} --out-link=CompiledSamples
@@ -132,8 +132,6 @@ jobs:
   pool:
     vmImage: 'macOS-11'
   steps:
-  - checkout: self
-    submodules: false
   - script: |
       curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
     displayName: Install Nix
@@ -141,6 +139,8 @@ jobs:
       nix-env -iA cachix -f https://cachix.org/api/v1/install
       cachix use autc04
     displayName: Setup Cachix
+  - checkout: self
+    submodules: false
   - script: |
       nix develop .#${TARGET} --profile dev-profile -c true
       nix build .#samples-${TARGET} --out-link=CompiledSamples

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,7 +99,7 @@ jobs:
       curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
     displayName: Install Nix
   - script: |
-      nix-env -iA cachix -f https://cachix.org/api/v1/install
+      nix profile install --accept-flake-config nixpkgs#cachix
       cachix use autc04
     displayName: Setup Cachix
   - checkout: self
@@ -136,7 +136,7 @@ jobs:
       curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
     displayName: Install Nix
   - script: |
-      nix-env -iA cachix -f https://cachix.org/api/v1/install
+      nix profile install --accept-flake-config nixpkgs#cachix
       cachix use autc04
     displayName: Setup Cachix
   - checkout: self

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,19 +99,21 @@ jobs:
       curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
     displayName: Install Nix
   - script: |
+      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
       nix profile install --accept-flake-config nixpkgs#cachix
       cachix use autc04
     displayName: Setup Cachix
   - checkout: self
     submodules: false
   - script: |
+      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
       nix develop .#${TARGET} --profile dev-profile -c true
       nix build .#samples-${TARGET} --out-link=CompiledSamples
     displayName: Build
   - publish: CompiledSamples
     artifact: Samples ($(TARGET))
   - script: |
-      set -e
+      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
       export CACHIX_AUTH_TOKEN=$(CACHIX_AUTH_TOKEN)
       cachix push autc04 dev-profile
       cachix push autc04 CompiledSamples
@@ -136,19 +138,21 @@ jobs:
       curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
     displayName: Install Nix
   - script: |
+      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
       nix profile install --accept-flake-config nixpkgs#cachix
       cachix use autc04
     displayName: Setup Cachix
   - checkout: self
     submodules: false
   - script: |
+      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
       nix develop .#${TARGET} --profile dev-profile -c true
       nix build .#samples-${TARGET} --out-link=CompiledSamples
     displayName: Build
   - publish: CompiledSamples
     artifact: Samples ($(TARGET))
   - script: |
-      set -e
+      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
       export CACHIX_AUTH_TOKEN=$(CACHIX_AUTH_TOKEN)
       cachix push autc04 dev-profile
       cachix push autc04 CompiledSamples

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,8 @@ jobs:
     vmImage: 'ubuntu-22.04'
   steps:
   - script: |
-      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
+      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
+        | sh -s -- install --no-confirm --extra-conf "trusted-users = root vsts"
     displayName: Install Nix
   - script: |
       . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
@@ -135,7 +136,8 @@ jobs:
     vmImage: 'macOS-11'
   steps:
   - script: |
-      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
+      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
+        | sh -s -- install --no-confirm --extra-conf "trusted-users = root runner"
     displayName: Install Nix
   - script: |
       . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,84 +3,84 @@ trigger:
 
 jobs:
 
-- job: Linux
-  pool:
-    vmImage: 'ubuntu-latest'
-  timeoutInMinutes: 90
-  variables:
-  - group: Tokens  
-  steps:
-  - checkout: self
-    submodules: true
-
-  - task: Docker@2
-    inputs:
-      command: build
-      repository: ghcr.io/autc04/retro68-build
-      tags: latest
-      arguments: --target build
-    displayName: 'Build'
-  - task: Docker@2
-    inputs:
-      command: build
-      repository: ghcr.io/autc04/retro68
-      tags: latest
-      arguments: --target release
-    displayName: 'Build release'
-  - script: |
-      docker run --name retro68-build --rm -i -d ghcr.io/autc04/retro68-build:latest
-      docker exec -i retro68-build /bin/bash <<"EOF"
-        cd /Retro68-build
-        curl -L -O https://github.com/autc04/executor/releases/download/v0.1.0/Executor2000-0.1.0-Linux.tar.bz2
-        tar xfvj Executor2000-0.1.0-Linux.tar.bz2 Executor2000-0.1.0-Linux/bin/executor-headless
-        echo "executor-path=`pwd`/Executor2000-0.1.0-Linux/bin/executor-headless" > ~/.LaunchAPPL.cfg
-        echo "emulator=executor" >> ~/.LaunchAPPL.cfg
-        ctest --no-compress-output -T test -E Carbon || true
-      EOF
-      mkdir build && docker cp retro68-build:/Retro68-build/Testing build
-      docker stop retro68-build
-    displayName: Run Tests using Executor 2000
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: 'CTest'
-      testResultsFiles: build/Testing/**/*.xml
-      buildPlatform: 'x86_64-linux'
-  - script: |
-      docker login ghcr.io/autc04 -u autc04 -p $GHCR_TOKEN
-      docker push ghcr.io/autc04/retro68
-    env:
-      GHCR_TOKEN: $(GHCR_TOKEN)
-    displayName: 'Push release to GHCR'
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-
-- job: macOS
-  pool:
-    vmImage: 'macOS-11'
-  timeoutInMinutes: 90
-  steps:
-  - checkout: self
-    submodules: true
-  - script: |
-      brew install boost cmake gmp mpfr libmpc bison
-    displayName: 'Brew prerequisites'
-  - script: |
-      mkdir build
-      cd build
-      ../build-toolchain.bash
-    displayName: Build
-  - script: |
-      cd build
-      curl -L -O https://github.com/autc04/executor/releases/download/v0.1.0/Executor2000-0.1.0-Darwin.tar.bz2
-      tar xfvj Executor2000-0.1.0-Darwin.tar.bz2 Executor2000-0.1.0-Darwin/bin/executor-headless
-      echo "executor-path=`pwd`/Executor2000-0.1.0-Darwin/bin/executor-headless" > ~/.LaunchAPPL.cfg
-      echo "emulator=executor" >> ~/.LaunchAPPL.cfg
-      ctest --no-compress-output -T test -E Carbon || true
-    displayName: Run Tests using Executor 2000
-  - task: PublishTestResults@2
-    inputs:
-      testResultsFormat: 'CTest'
-      testResultsFiles: build/Testing/**/*.xml
-      buildPlatform: 'x86_64-macos'
+#- job: Linux
+#  pool:
+#    vmImage: 'ubuntu-latest'
+#  timeoutInMinutes: 90
+#  variables:
+#  - group: Tokens  
+#  steps:
+#  - checkout: self
+#    submodules: true
+#
+#  - task: Docker@2
+#    inputs:
+#      command: build
+#      repository: ghcr.io/autc04/retro68-build
+#      tags: latest
+#      arguments: --target build
+#    displayName: 'Build'
+#  - task: Docker@2
+#    inputs:
+#      command: build
+#      repository: ghcr.io/autc04/retro68
+#      tags: latest
+#      arguments: --target release
+#    displayName: 'Build release'
+#  - script: |
+#      docker run --name retro68-build --rm -i -d ghcr.io/autc04/retro68-build:latest
+#      docker exec -i retro68-build /bin/bash <<"EOF"
+#        cd /Retro68-build
+#        curl -L -O https://github.com/autc04/executor/releases/download/v0.1.0/Executor2000-0.1.0-Linux.tar.bz2
+#        tar xfvj Executor2000-0.1.0-Linux.tar.bz2 Executor2000-0.1.0-Linux/bin/executor-headless
+#        echo "executor-path=`pwd`/Executor2000-0.1.0-Linux/bin/executor-headless" > ~/.LaunchAPPL.cfg
+#        echo "emulator=executor" >> ~/.LaunchAPPL.cfg
+#        ctest --no-compress-output -T test -E Carbon || true
+#      EOF
+#      mkdir build && docker cp retro68-build:/Retro68-build/Testing build
+#      docker stop retro68-build
+#    displayName: Run Tests using Executor 2000
+#  - task: PublishTestResults@2
+#    inputs:
+#      testResultsFormat: 'CTest'
+#      testResultsFiles: build/Testing/**/*.xml
+#      buildPlatform: 'x86_64-linux'
+#  - script: |
+#      docker login ghcr.io/autc04 -u autc04 -p $GHCR_TOKEN
+#      docker push ghcr.io/autc04/retro68
+#    env:
+#      GHCR_TOKEN: $(GHCR_TOKEN)
+#    displayName: 'Push release to GHCR'
+#    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+#
+#- job: macOS
+#  pool:
+#    vmImage: 'macOS-11'
+#  timeoutInMinutes: 90
+#  steps:
+#  - checkout: self
+#    submodules: true
+#  - script: |
+#      brew install boost cmake gmp mpfr libmpc bison
+#    displayName: 'Brew prerequisites'
+#  - script: |
+#      mkdir build
+#      cd build
+#      ../build-toolchain.bash
+#    displayName: Build
+#  - script: |
+#      cd build
+#      curl -L -O https://github.com/autc04/executor/releases/download/v0.1.0/Executor2000-0.1.0-Darwin.tar.bz2
+#      tar xfvj Executor2000-0.1.0-Darwin.tar.bz2 Executor2000-0.1.0-Darwin/bin/executor-headless
+#      echo "executor-path=`pwd`/Executor2000-0.1.0-Darwin/bin/executor-headless" > ~/.LaunchAPPL.cfg
+#      echo "emulator=executor" >> ~/.LaunchAPPL.cfg
+#      ctest --no-compress-output -T test -E Carbon || true
+#    displayName: Run Tests using Executor 2000
+#  - task: PublishTestResults@2
+#    inputs:
+#      testResultsFormat: 'CTest'
+#      testResultsFiles: build/Testing/**/*.xml
+#      buildPlatform: 'x86_64-macos'
 
 - job: NixLinux
   strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,7 +98,7 @@ jobs:
   - checkout: self
     submodules: false
   - script: |
-      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
     displayName: Install Nix
   - script: |
       nix-env -iA cachix -f https://cachix.org/api/v1/install
@@ -135,7 +135,7 @@ jobs:
   - checkout: self
     submodules: false
   - script: |
-      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
     displayName: Install Nix
   - script: |
       nix-env -iA cachix -f https://cachix.org/api/v1/install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,34 +93,28 @@ jobs:
         TARGET: carbon
     maxParallel: 2
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-22.04'
   steps:
   - checkout: self
-    submodules: true
+    submodules: false
   - script: |
-      docker run -i --name nix -v`pwd`:/src nixos/nix:2.18.1 <<EOF
-        nix-env -iA cachix -f https://cachix.org/api/v1/install
-        cachix use autc04
-        nix-build src -A ${TARGET}.retro68.samples
-      EOF
-    displayName: Build inside nixos/nix docker
+      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+    displayName: Install Nix
   - script: |
-      mkdir CompiledSamples
-      cd CompiledSamples
-      docker cp -L nix:result - | tar x --strip-components 1
-    displayName: Copy result out of docker
-
+      nix-env -iA cachix -f https://cachix.org/api/v1/install
+      cachix use autc04
+    displayName: Setup Cachix
+  - script: |
+      nix develop .#${TARGET} --profile dev-profile -c true
+      nix build .#samples-${TARGET} --out-link=CompiledSamples
+    displayName: Build
   - publish: CompiledSamples
     artifact: Samples ($(TARGET))
   - script: |
-      docker start nix -i <<EOF || true
-          set -e
-          export CACHIX_AUTH_TOKEN=$(CACHIX_AUTH_TOKEN)
-          cd src
-          nix-build -A ${TARGET}.retro68.samples | cachix push autc04
-          nix-shell -A ${TARGET} --command exit
-          nix-store -qR --include-outputs \$(nix-instantiate default.nix -A ${TARGET}) | cachix push autc04
-      EOF
+      set -e
+      export CACHIX_AUTH_TOKEN=$(CACHIX_AUTH_TOKEN)
+      cachix push autc04 dev-profile
+      cachix push autc04 CompiledSamples
     displayName: Push to Cachix
     condition: and(succeeded(), ne(variables['CACHIX_AUTH_TOKEN'], ''))
 
@@ -138,28 +132,28 @@ jobs:
   pool:
     vmImage: 'macOS-11'
   steps:
-  - script: |
-      export NIX_EXTRA_CONF="trusted-users = root runner"
-      sh <(curl -L https://nixos.org/nix/install)
-    displayName: Install nix
-  - script: |
-      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-      nix-env -iA cachix -f https://cachix.org/api/v1/install
-      cachix use autc04
-    displayName: setup cachix
-
   - checkout: self
     submodules: false
   - script: |
-      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-      nix-build -A $(TARGET).retro68.samples
-    displayName: build
+      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+    displayName: Install Nix
   - script: |
-      . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+      nix-env -iA cachix -f https://cachix.org/api/v1/install
+      cachix use autc04
+    displayName: Setup Cachix
+  - script: |
+      nix develop .#${TARGET} --profile dev-profile -c true
+      nix build .#samples-${TARGET} --out-link=CompiledSamples
+    displayName: Build
+  - publish: CompiledSamples
+    artifact: Samples ($(TARGET))
+  - script: |
+      set -e
       export CACHIX_AUTH_TOKEN=$(CACHIX_AUTH_TOKEN)
-      nix-build -A $(TARGET).retro68.samples | (cachix push autc04 || true)
-      nix-shell -A $(TARGET) --command exit
-      nix-store -qR --include-outputs `nix-instantiate default.nix -A $(TARGET)` | (cachix push autc04 || true)
+      cachix push autc04 dev-profile
+      cachix push autc04 CompiledSamples
     displayName: Push to Cachix
     condition: and(succeeded(), ne(variables['CACHIX_AUTH_TOKEN'], ''))
 
+  #export NIX_EXTRA_CONF="trusted-users = root runner"
+      #. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,9 @@
 let sources = import ./nix/sources.nix;
-in { system ? builtins.currentSystem, nixpkgs ? sources.nixpkgs, 
-  multiversal_src ?  if builtins.pathExists ./multiversal/make-multiverse.rb then
-    ./multiversal
-  else
-    sources.multiversal,
-  ... }:
+in { system ? builtins.currentSystem, nixpkgs ? sources.nixpkgs
+, multiversal_src ? if builtins.pathExists ./multiversal/make-multiverse.rb then
+  ./multiversal
+else
+  sources.multiversal, ... }:
 
 let
   retroPlatforms = import nix/platforms.nix;
@@ -30,8 +29,7 @@ let
       crossSystem = plat;
       config = { allowUnsupportedSystem = true; };
     }) retroPlatforms;
-  targetPkgs = lib.mapAttrs (name: cross:
-    cross.buildPackages) crossPkgs;
+  targetPkgs = lib.mapAttrs (name: cross: cross.buildPackages) crossPkgs;
 
   shell = lib.mapAttrs (name: cross:
     cross.mkShell {
@@ -44,8 +42,10 @@ let
       buildInputs = [ cross.retro68.console ];
     } // cross) crossPkgs;
 
-in shell.m68k // shell // {
+in builtins.trace
+"Warning: Retro68's default.nix is deprecated and will disappear soon. Please use the flake instead."
+(shell.m68k // shell // {
   inherit overlay;
   inherit (overlaidPkgs) retro68;
   targetPkg = targetPkgs;
-}
+})

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,12 @@
 let sources = import ./nix/sources.nix;
-in { system ? builtins.currentSystem, nixpkgs ? sources.nixpkgs
-, multiversal_src ? if builtins.pathExists ./multiversal/make-multiverse.rb then
-  ./multiversal
-else
-  sources.multiversal, ... }:
+in { system ? builtins.currentSystem
+   , nixpkgs ? sources.nixpkgs
+   , multiversal_src ? if builtins.pathExists ./multiversal/make-multiverse.rb then
+       ./multiversal
+     else
+       sources.multiversal
+   , ...
+   }:
 
 let
   retroPlatforms = import nix/platforms.nix;
@@ -22,30 +25,36 @@ let
     overlays = [ overlay ];
   };
 
-  crossPkgs = lib.mapAttrs (name: plat:
-    import nixpkgs {
-      inherit system;
-      overlays = [ overlay ];
-      crossSystem = plat;
-      config = { allowUnsupportedSystem = true; };
-    }) retroPlatforms;
+  crossPkgs = lib.mapAttrs
+    (name: plat:
+      import nixpkgs {
+        inherit system;
+        overlays = [ overlay ];
+        crossSystem = plat;
+        config = { allowUnsupportedSystem = true; };
+      })
+    retroPlatforms;
   targetPkgs = lib.mapAttrs (name: cross: cross.buildPackages) crossPkgs;
 
-  shell = lib.mapAttrs (name: cross:
-    cross.mkShell {
-      nativeBuildInputs = with overlaidPkgs; [
-        retro68.hfsutils
-        retro68.tools
-        cmake
-        gnumake
-      ];
-      buildInputs = [ cross.retro68.console ];
-    } // cross) crossPkgs;
+  shell = lib.mapAttrs
+    (name: cross:
+      cross.mkShell
+        {
+          nativeBuildInputs = with overlaidPkgs; [
+            retro68.hfsutils
+            retro68.tools
+            cmake
+            gnumake
+          ];
+          buildInputs = [ cross.retro68.console ];
+        } // cross)
+    crossPkgs;
 
-in builtins.trace
-"Warning: Retro68's default.nix is deprecated and will disappear soon. Please use the flake instead."
-(shell.m68k // shell // {
-  inherit overlay;
-  inherit (overlaidPkgs) retro68;
-  targetPkg = targetPkgs;
-})
+in
+builtins.trace
+  "Warning: Retro68's default.nix is deprecated and will disappear soon. Please use the flake instead."
+  (shell.m68k // shell // {
+    inherit overlay;
+    inherit (overlaidPkgs) retro68;
+    targetPkg = targetPkgs;
+  })

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,63 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1701473968,
+        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1702312524,
+        "narHash": "sha256-gkZJRDBUCpTPBvQk25G0B7vfbpEYM5s5OZqghkjZsnE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a9bf124c46ef298113270b1f84a164865987a91c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1701253981,
+        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
     "multiversal": {
       "flake": false,
       "locked": {
-        "lastModified": 1682955462,
-        "narHash": "sha256-fOLYuSJOWh/iE7JelpeuT4NgZ/5bZivqV+o9LtiJGxA=",
+        "lastModified": 1703617805,
+        "narHash": "sha256-GngLWR9i+hC7hJ+ZkKlRK4K63lIJ4D/CMXZwefcVAqw=",
         "owner": "autc04",
         "repo": "multiversal",
-        "rev": "1170bce4c98f1956ad73ca335479d510cd6e8620",
+        "rev": "27c08c654bbd48d23f025741e3a584b59374904a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -36,16 +36,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702312524,
-        "narHash": "sha256-gkZJRDBUCpTPBvQk25G0B7vfbpEYM5s5OZqghkjZsnE=",
+        "lastModified": 1703200384,
+        "narHash": "sha256-q5j06XOsy0qHOarsYPfZYJPWbTbc8sryRxianlEPJN0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a9bf124c46ef298113270b1f84a164865987a91c",
+        "rev": "0b3d618173114c64ab666f557504d6982665d328",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -17,6 +17,22 @@
         "type": "indirect"
       }
     },
+    "multiversal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1682955462,
+        "narHash": "sha256-fOLYuSJOWh/iE7JelpeuT4NgZ/5bZivqV+o9LtiJGxA=",
+        "owner": "autc04",
+        "repo": "multiversal",
+        "rev": "1170bce4c98f1956ad73ca335479d510cd6e8620",
+        "type": "github"
+      },
+      "original": {
+        "owner": "autc04",
+        "repo": "multiversal",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1702312524,
@@ -54,6 +70,7 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
+        "multiversal": "multiversal",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -13,8 +13,9 @@
         "type": "github"
       },
       "original": {
-        "id": "flake-parts",
-        "type": "indirect"
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
       }
     },
     "multiversal": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Description for the project";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [
+        # To import a flake module
+        # 1. Add foo to inputs
+        # 2. Add foo as a parameter to the outputs function
+        # 3. Add here: foo.flakeModule
+
+      ];
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      perSystem = { config, self', inputs', pkgs, system, ... }: {
+        # Per-system attributes can be defined here. The self' and inputs'
+        # module parameters provide easy access to attributes of the same
+        # system.
+
+        # Equivalent to  inputs'.nixpkgs.legacyPackages.hello;
+        packages.default = pkgs.hello;
+      };
+      flake = {
+        # The usual flake attributes can be defined here, including system-
+        # agnostic ones like nixosModule and system-enumerating ones, although
+        # those are more easily expressed in perSystem.
+
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Description for the project";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
     multiversal.url = "github:autc04/multiversal";
     multiversal.flake = false;
     flake-parts.url = "github:hercules-ci/flake-parts";

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,8 @@
                 } // cross)
             self'.legacyPackages.crossPkgs;
 
+          packages.tools = pkgs.retro68.tools;
+          packages.hfsutils = pkgs.retro68.hfsutils;
 
         };
       flake = {

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,8 @@
         {
           _module.args.pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.default ]; };
 
+          formatter = pkgs.nixpkgs-fmt;
+
           legacyPackages.pkgsCross = lib.mapAttrs
             (name: plat:
               import nixpkgs {
@@ -52,7 +54,7 @@
             tools = pkgs.retro68.tools;
             hfsutils = pkgs.retro68.hfsutils;
 
-            default = pkgs.runCommand "Retro68" {} ''
+            default = pkgs.runCommand "Retro68" { } ''
               mkdir $out
               mkdir $out/m68k-apple-macos
               mkdir $out/powerpc-apple-macos
@@ -85,8 +87,9 @@
       flake = {
         overlays.default =
           lib.composeManyExtensions [
-            ((import nix/overlay.nix) { 
-              multiversal_src = if builtins.pathExists ./multiversal/make-multiverse.rb
+            ((import nix/overlay.nix) {
+              multiversal_src =
+                if builtins.pathExists ./multiversal/make-multiverse.rb
                 then ./multiversal
                 else multiversal;
             })

--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,12 @@
             ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.m68k.buildPackages.retro68.gcc_unwrapped}/. $out
             ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.powerpc.buildPackages.retro68.gcc_unwrapped}/. $out
           '';
+
+          packages.samples = pkgs.linkFarm "Retro68-Samples" [
+            { name = "m68k"; path = self'.legacyPackages.crossPkgs.m68k.retro68.samples; }
+            { name = "powerpc"; path = self'.legacyPackages.crossPkgs.powerpc.retro68.samples; }
+            { name = "carbon"; path = self'.legacyPackages.crossPkgs.carbon.retro68.samples; }
+          ];
         };
       flake = {
         overlays.default =

--- a/flake.nix
+++ b/flake.nix
@@ -48,35 +48,39 @@
                 } // cross)
             self'.legacyPackages.crossPkgs;
 
-          packages.tools = pkgs.retro68.tools;
-          packages.hfsutils = pkgs.retro68.hfsutils;
+          packages = {
+            tools = pkgs.retro68.tools;
+            hfsutils = pkgs.retro68.hfsutils;
 
-          packages.default = pkgs.runCommand "Retro68" {} ''
-            mkdir $out
-            mkdir $out/m68k-apple-macos
-            mkdir $out/powerpc-apple-macos
-            ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.m68k.retro68.libretro}/. $out/m68k-apple-macos
-            ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.m68k.retro68.multiversal}/. $out/m68k-apple-macos
-            ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.powerpc.retro68.libretro}/. $out/powerpc-apple-macos
-            ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.powerpc.retro68.multiversal}/. $out/powerpc-apple-macos
-            ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.carbon.retro68.libretro}/. $out/powerpc-apple-macos
-            ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.carbon.retro68.multiversal}/. $out/powerpc-apple-macos
-            ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.retro68.tools}/. $out
-            ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.retro68.hfsutils}/. $out
-            ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.cmake}/. $out
-            ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.gnumake}/. $out
-            ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.ninja}/. $out
+            default = pkgs.runCommand "Retro68" {} ''
+              mkdir $out
+              mkdir $out/m68k-apple-macos
+              mkdir $out/powerpc-apple-macos
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.m68k.retro68.libretro}/. $out/m68k-apple-macos
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.m68k.retro68.multiversal}/. $out/m68k-apple-macos
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.powerpc.retro68.libretro}/. $out/powerpc-apple-macos
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.powerpc.retro68.multiversal}/. $out/powerpc-apple-macos
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.carbon.retro68.libretro}/. $out/powerpc-apple-macos
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.carbon.retro68.multiversal}/. $out/powerpc-apple-macos
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.retro68.tools}/. $out
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.retro68.hfsutils}/. $out
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.cmake}/. $out
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.gnumake}/. $out
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.ninja}/. $out
 
-            ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.m68k.buildPackages.retro68.gcc_unwrapped}/. $out
-            ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.powerpc.buildPackages.retro68.gcc_unwrapped}/. $out
-            ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.carbon.buildPackages.retro68.gcc_unwrapped}/. $out
-          '';
+              ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.m68k.buildPackages.retro68.gcc_unwrapped}/. $out
+              ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.powerpc.buildPackages.retro68.gcc_unwrapped}/. $out
+              ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.carbon.buildPackages.retro68.gcc_unwrapped}/. $out
+            '';
 
-          packages.samples = pkgs.linkFarm "Retro68-Samples" [
-            { name = "m68k"; path = self'.legacyPackages.crossPkgs.m68k.retro68.samples; }
-            { name = "powerpc"; path = self'.legacyPackages.crossPkgs.powerpc.retro68.samples; }
-            { name = "carbon"; path = self'.legacyPackages.crossPkgs.carbon.retro68.samples; }
-          ];
+            samples = pkgs.linkFarm "Retro68-Samples" [
+              { name = "m68k"; path = self'.legacyPackages.crossPkgs.m68k.retro68.samples; }
+              { name = "powerpc"; path = self'.legacyPackages.crossPkgs.powerpc.retro68.samples; }
+              { name = "carbon"; path = self'.legacyPackages.crossPkgs.carbon.retro68.samples; }
+            ];
+          } // lib.mapAttrs'
+            (name: cross: lib.nameValuePair "samples-${name}" cross.retro68.samples)
+            self'.legacyPackages.crossPkgs;
         };
       flake = {
         overlays.default =

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     multiversal.url = "github:autc04/multiversal";
     multiversal.flake = false;
+    flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
   outputs = inputs@{ flake-parts, nixpkgs, multiversal, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,8 @@
             ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.m68k.retro68.multiversal}/. $out/m68k-apple-macos
             ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.powerpc.retro68.libretro}/. $out/powerpc-apple-macos
             ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.powerpc.retro68.multiversal}/. $out/powerpc-apple-macos
+            ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.carbon.retro68.libretro}/. $out/powerpc-apple-macos
+            ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.carbon.retro68.multiversal}/. $out/powerpc-apple-macos
             ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.retro68.tools}/. $out
             ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.retro68.hfsutils}/. $out
             ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.cmake}/. $out
@@ -67,6 +69,7 @@
 
             ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.m68k.buildPackages.retro68.gcc_unwrapped}/. $out
             ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.powerpc.buildPackages.retro68.gcc_unwrapped}/. $out
+            ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.carbon.buildPackages.retro68.gcc_unwrapped}/. $out
           '';
 
           packages.samples = pkgs.linkFarm "Retro68-Samples" [

--- a/flake.nix
+++ b/flake.nix
@@ -72,7 +72,11 @@
       flake = {
         overlays.default =
           lib.composeManyExtensions [
-            ((import nix/overlay.nix) { multiversal_src = multiversal; })
+            ((import nix/overlay.nix) { 
+              multiversal_src = if builtins.pathExists ./multiversal/make-multiverse.rb
+                then ./multiversal
+                else multiversal;
+            })
             (import nix/universal.nix)
             (import nix/samples.nix)
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
                     retro68.tools
                     cmake
                     gnumake
+                    ninja
                   ];
                   buildInputs = [ cross.retro68.console ];
                 } // cross)

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,23 @@
           packages.tools = pkgs.retro68.tools;
           packages.hfsutils = pkgs.retro68.hfsutils;
 
+          packages.default = pkgs.runCommand "Retro68" {} ''
+            mkdir $out
+            mkdir $out/m68k-apple-macos
+            mkdir $out/powerpc-apple-macos
+            ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.m68k.retro68.libretro}/. $out/m68k-apple-macos
+            ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.m68k.retro68.multiversal}/. $out/m68k-apple-macos
+            ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.powerpc.retro68.libretro}/. $out/powerpc-apple-macos
+            ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.powerpc.retro68.multiversal}/. $out/powerpc-apple-macos
+            ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.retro68.tools}/. $out
+            ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.retro68.hfsutils}/. $out
+            ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.cmake}/. $out
+            ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.gnumake}/. $out
+            ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.ninja}/. $out
+
+            ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.m68k.buildPackages.retro68.gcc_unwrapped}/. $out
+            ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.powerpc.buildPackages.retro68.gcc_unwrapped}/. $out
+          '';
         };
       flake = {
         overlays.default =

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
         {
           _module.args.pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.default ]; };
 
-          legacyPackages.crossPkgs = lib.mapAttrs
+          legacyPackages.pkgsCross = lib.mapAttrs
             (name: plat:
               import nixpkgs {
                 inherit system;
@@ -46,7 +46,7 @@
                   ];
                   buildInputs = [ cross.retro68.console ];
                 } // cross)
-            self'.legacyPackages.crossPkgs;
+            self'.legacyPackages.pkgsCross;
 
           packages = {
             tools = pkgs.retro68.tools;
@@ -56,31 +56,31 @@
               mkdir $out
               mkdir $out/m68k-apple-macos
               mkdir $out/powerpc-apple-macos
-              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.m68k.retro68.libretro}/. $out/m68k-apple-macos
-              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.m68k.retro68.multiversal}/. $out/m68k-apple-macos
-              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.powerpc.retro68.libretro}/. $out/powerpc-apple-macos
-              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.powerpc.retro68.multiversal}/. $out/powerpc-apple-macos
-              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.carbon.retro68.libretro}/. $out/powerpc-apple-macos
-              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.crossPkgs.carbon.retro68.multiversal}/. $out/powerpc-apple-macos
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.pkgsCross.m68k.retro68.libretro}/. $out/m68k-apple-macos
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.pkgsCross.m68k.retro68.multiversal}/. $out/m68k-apple-macos
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.pkgsCross.powerpc.retro68.libretro}/. $out/powerpc-apple-macos
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.pkgsCross.powerpc.retro68.multiversal}/. $out/powerpc-apple-macos
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.pkgsCross.carbon.retro68.libretro}/. $out/powerpc-apple-macos
+              ${pkgs.xorg.lndir}/bin/lndir -silent ${self'.legacyPackages.pkgsCross.carbon.retro68.multiversal}/. $out/powerpc-apple-macos
               ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.retro68.tools}/. $out
               ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.retro68.hfsutils}/. $out
               ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.cmake}/. $out
               ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.gnumake}/. $out
               ${pkgs.xorg.lndir}/bin/lndir -silent ${pkgs.ninja}/. $out
 
-              ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.m68k.buildPackages.retro68.gcc_unwrapped}/. $out
-              ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.powerpc.buildPackages.retro68.gcc_unwrapped}/. $out
-              ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.crossPkgs.carbon.buildPackages.retro68.gcc_unwrapped}/. $out
+              ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.pkgsCross.m68k.buildPackages.retro68.gcc_unwrapped}/. $out
+              ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.pkgsCross.powerpc.buildPackages.retro68.gcc_unwrapped}/. $out
+              ${pkgs.rsync}/bin/rsync -a ${self'.legacyPackages.pkgsCross.carbon.buildPackages.retro68.gcc_unwrapped}/. $out
             '';
 
             samples = pkgs.linkFarm "Retro68-Samples" [
-              { name = "m68k"; path = self'.legacyPackages.crossPkgs.m68k.retro68.samples; }
-              { name = "powerpc"; path = self'.legacyPackages.crossPkgs.powerpc.retro68.samples; }
-              { name = "carbon"; path = self'.legacyPackages.crossPkgs.carbon.retro68.samples; }
+              { name = "m68k"; path = self'.legacyPackages.pkgsCross.m68k.retro68.samples; }
+              { name = "powerpc"; path = self'.legacyPackages.pkgsCross.powerpc.retro68.samples; }
+              { name = "carbon"; path = self'.legacyPackages.pkgsCross.carbon.retro68.samples; }
             ];
           } // lib.mapAttrs'
             (name: cross: lib.nameValuePair "samples-${name}" cross.retro68.samples)
-            self'.legacyPackages.crossPkgs;
+            self'.legacyPackages.pkgsCross;
         };
       flake = {
         overlays.default =

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,0 +1,4 @@
+# turn off garnix for now
+builds:
+  include: []
+  exclude: []

--- a/hfsutils/libhfs/data.h
+++ b/hfsutils/libhfs/data.h
@@ -19,6 +19,8 @@
  * $Id: data.h,v 1.7 1998/11/02 22:08:58 rob Exp $
  */
 
+#include <time.h>
+
 extern const unsigned char hfs_charorder[];
 
   signed  char d_getsb(register const unsigned char *);

--- a/hfsutils/librsrc/data.h
+++ b/hfsutils/librsrc/data.h
@@ -19,6 +19,8 @@
  * $Id: data.h,v 1.5 1998/04/11 08:27:18 rob Exp $
  */
 
+# include <time.h>
+
 extern const unsigned char hfs_charorder[];
 
 signed char d_getsb(const unsigned char *);

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -251,7 +251,10 @@ pkgs: prevPkgs: {
 
   # binutils -- binutils with the wrappers provided by nixpkgs 
   binutils = if (prevPkgs.targetPlatform ? retro68) then
-    pkgs.wrapBintoolsWith { bintools = pkgs.retro68.binutils_unwrapped; }
+    pkgs.wrapBintoolsWith { 
+      bintools = pkgs.retro68.binutils_unwrapped; 
+      libc = null;
+    }
   else
     prevPkgs.binutils;
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -276,9 +276,4 @@ pkgs: prevPkgs: {
     }
   else
     prevPkgs.gcc;
-
-  # no separate libc package for now
-  libcCrossChooser = name:
-    if name == "retro68" then null else prevPkgs.libcCrossChooser name;
-
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -10,7 +10,7 @@ pkgs: prevPkgs: {
           src = ../.;
           nativeBuildInputs = [ cmake bison flex ruby ninja bash ];
           buildInputs = [ boost gmp mpfr libmpc zlib ]
-            ++ lib.optional hostPlatform.isDarwin
+          ++ lib.optional hostPlatform.isDarwin
             darwin.apple_sdk.frameworks.ApplicationServices;
           buildCommand = ''
             bash $src/build-toolchain.bash --ninja --prefix=$out --no-carbon
@@ -56,7 +56,7 @@ pkgs: prevPkgs: {
 
           nativeBuildInputs = [ cmake bison flex ];
           buildInputs = [ boost zlib retro68.hfsutils ]
-            ++ lib.optional hostPlatform.isDarwin
+          ++ lib.optional hostPlatform.isDarwin
             darwin.apple_sdk.frameworks.ApplicationServices;
         };
 
@@ -75,15 +75,17 @@ pkgs: prevPkgs: {
             ++ stdenv.targetPlatform.retro68BinutilsConfig or [ ];
           enableParallelBuilding = true;
 
-          postInstall = let
-            ld = "$out/bin/${stdenv.targetPlatform.config}-ld";
-            ld_real = "$out/bin/${stdenv.targetPlatform.config}-ld.real";
+          postInstall =
+            let
+              ld = "$out/bin/${stdenv.targetPlatform.config}-ld";
+              ld_real = "$out/bin/${stdenv.targetPlatform.config}-ld.real";
 
-          in ''
-            mv ${ld} ${ld_real}
+            in
+            ''
+              mv ${ld} ${ld_real}
 
-            echo "#!${stdenv.shell}" > ${ld}
-            echo "exec \$'' + ''
+              echo "#!${stdenv.shell}" > ${ld}
+              echo "exec \$'' + ''
               {RETRO68_LD_WRAPPER_${stdenv.targetPlatform.cmakeSystemName}-${ld_real}} \"\$@\"" >> ${ld}
                               chmod +x ${ld}
 
@@ -117,12 +119,12 @@ pkgs: prevPkgs: {
             make -j$NIX_BUILD_CORES
             make install
           '';
-          env.CXXFLAGS="--std=c++14"; # gcc 9 doesn't seem to like C++17
+          env.CXXFLAGS = "--std=c++14"; # gcc 9 doesn't seem to like C++17
         };
 
       # binutils -- binutils with the wrappers provided by nixpkgs 
-      binutils = pkgs.wrapBintoolsWith { 
-        bintools = pkgs.retro68.binutils_unwrapped; 
+      binutils = pkgs.wrapBintoolsWith {
+        bintools = pkgs.retro68.binutils_unwrapped;
         libc = null;
       };
 
@@ -147,54 +149,56 @@ pkgs: prevPkgs: {
 
     } // prevPkgs.lib.optionalAttrs (prevPkgs.hostPlatform ? retro68) {
 
-      setup_hook = let
-        systemName = pkgs.targetPlatform.cmakeSystemName;
-        toolchain = pkgs.writeTextFile {
-          name = "retro68.cmake-toolchain";
-          text = ''
-            set(CMAKE_SYSTEM_NAME ${systemName})
-            set(CMAKE_SYSTEM_VERSION 1)
-            set(CMAKE_CROSSCOMPILING TRUE)
+      setup_hook =
+        let
+          systemName = pkgs.targetPlatform.cmakeSystemName;
+          toolchain = pkgs.writeTextFile {
+            name = "retro68.cmake-toolchain";
+            text = ''
+              set(CMAKE_SYSTEM_NAME ${systemName})
+              set(CMAKE_SYSTEM_VERSION 1)
+              set(CMAKE_CROSSCOMPILING TRUE)
 
-            set(REZ "${pkgs.buildPackages.retro68.tools}/bin/Rez" )
-            set(REZ_TEMPLATES_PATH ${pkgs.retro68.libretro}/RIncludes)
+              set(REZ "${pkgs.buildPackages.retro68.tools}/bin/Rez" )
+              set(REZ_TEMPLATES_PATH ${pkgs.retro68.libretro}/RIncludes)
 
-            set(MAKE_PEF "${pkgs.buildPackages.retro68.tools}/bin/MakePEF" )
+              set(MAKE_PEF "${pkgs.buildPackages.retro68.tools}/bin/MakePEF" )
 
-            include(${../cmake/add_application.cmake})
-          '' + (pkgs.lib.optionalString (systemName == "RetroCarbon") ''
-            set(CMAKE_EXE_LINKER_FLAGS_INIT "-carbon")
-            set(CMAKE_SHARED_LINKER_FLAGS_INIT "-carbon")
-            add_definitions( -DTARGET_API_MAC_CARBON=1 )
-          '');
-        };
-        hook = pkgs.writeTextFile {
-          name = "retro68.setup_hook";
-          text = ''
-            export CMAKE_TOOLCHAIN_FILE=${toolchain}
+              include(${../cmake/add_application.cmake})
+            '' + (pkgs.lib.optionalString (systemName == "RetroCarbon") ''
+              set(CMAKE_EXE_LINKER_FLAGS_INIT "-carbon")
+              set(CMAKE_SHARED_LINKER_FLAGS_INIT "-carbon")
+              add_definitions( -DTARGET_API_MAC_CARBON=1 )
+            '');
+          };
+          hook = pkgs.writeTextFile {
+            name = "retro68.setup_hook";
+            text = ''
+              export CMAKE_TOOLCHAIN_FILE=${toolchain}
 
-            retro68_addRIncludes() {
-              case $depHostOffset in
-                  -1) local role='BUILD_' ;;
-                  0)  local role="" ;;
-                  1)  local role='TARGET_' ;;
-                  *)  echo "retro68_addRIncludes: Error: Cannot be used with $depHostOffset-offset deps" >2;
-                      return 1 ;;
-              esac
+              retro68_addRIncludes() {
+                case $depHostOffset in
+                    -1) local role='BUILD_' ;;
+                    0)  local role="" ;;
+                    1)  local role='TARGET_' ;;
+                    *)  echo "retro68_addRIncludes: Error: Cannot be used with $depHostOffset-offset deps" >2;
+                        return 1 ;;
+                esac
 
-              if [[ -d "$1/RIncludes" ]]; then
-                  export REZ_INCLUDE_PATH+=":$1/RIncludes"
-              fi
-            }
+                if [[ -d "$1/RIncludes" ]]; then
+                    export REZ_INCLUDE_PATH+=":$1/RIncludes"
+                fi
+              }
 
-            addEnvHooks "$targetOffset" retro68_addRIncludes
+              addEnvHooks "$targetOffset" retro68_addRIncludes
 
-          '' + (pkgs.lib.optionalString (systemName == "Retro68") ''
-            export RETRO68_LD_WRAPPER_Retro68="${pkgs.buildPackages.retro68.tools}/bin/Elf2Mac"
-            export RETRO68_REAL_LD="${pkgs.buildPackages.retro68.binutils_unwrapped}/bin/m68k-apple-macos-ld.real"
-          '');
-        };
-      in pkgs.makeSetupHook { name = "retro68.setup_hook"; } hook;
+            '' + (pkgs.lib.optionalString (systemName == "Retro68") ''
+              export RETRO68_LD_WRAPPER_Retro68="${pkgs.buildPackages.retro68.tools}/bin/Elf2Mac"
+              export RETRO68_REAL_LD="${pkgs.buildPackages.retro68.binutils_unwrapped}/bin/m68k-apple-macos-ld.real"
+            '');
+          };
+        in
+        pkgs.makeSetupHook { name = "retro68.setup_hook"; } hook;
 
       # ----------- Retro68 core libraries -------------
 
@@ -221,14 +225,15 @@ pkgs: prevPkgs: {
 
       import_libraries = with pkgs;
         if stdenvNoCC.targetPlatform.system != "m68k-macos" then
-          stdenvNoCC.mkDerivation {
-            name = "retro68.import_libraries";
-            src = ../ImportLibraries;
-            buildCommand = ''
-              mkdir -p $out/lib
-              cp $src/*.a $out/lib/
-            '';
-          }
+          stdenvNoCC.mkDerivation
+            {
+              name = "retro68.import_libraries";
+              src = ../ImportLibraries;
+              buildCommand = ''
+                mkdir -p $out/lib
+                cp $src/*.a $out/lib/
+              '';
+            }
         else
           null;
 
@@ -243,7 +248,8 @@ pkgs: prevPkgs: {
               set(CMAKE_CROSSCOMPILING TRUE)
             '';
           };
-        in (pkgs.stdenv.override {
+        in
+        (pkgs.stdenv.override {
           cc = stdenv.cc.override { extraPackages = [ ]; };
         }).mkDerivation {
           name = "libretro";
@@ -279,14 +285,16 @@ pkgs: prevPkgs: {
   # binutils -- binutils with the wrappers provided by nixpkgs
   # note: on nix/darwin (as of nixpkgs 23.11), nixpkgs seems to 
   # ignore (or re-override) this override.
-  binutils = if (prevPkgs.targetPlatform ? retro68) then
-    pkgs.retro68.binutils
-  else
-    prevPkgs.binutils;
-  
+  binutils =
+    if (prevPkgs.targetPlatform ? retro68) then
+      pkgs.retro68.binutils
+    else
+      prevPkgs.binutils;
+
   # gcc -- gcc with the wrappers provided by nixpkgs
-  gcc = if (prevPkgs.targetPlatform ? retro68) then
-    pkgs.retro68.gcc
-  else
-    prevPkgs.gcc;
+  gcc =
+    if (prevPkgs.targetPlatform ? retro68) then
+      pkgs.retro68.gcc
+    else
+      prevPkgs.gcc;
 }

--- a/nix/platforms.nix
+++ b/nix/platforms.nix
@@ -2,7 +2,7 @@
   m68k = {
     system = "m68k-macos";
     config = "m68k-apple-macos";
-    libc = "retro68";
+    libc = null;
     parsed = {
       cpu = {
         name = "m68k";
@@ -27,7 +27,7 @@
   powerpc = {
     system = "powerpc-macos";
     config = "powerpc-apple-macos";
-    libc = "retro68";
+    libc = null;
     parsed = {
       cpu = {
         name = "powerpc";
@@ -52,7 +52,7 @@
   carbon = {
     system = "powerpc-carbon";
     config = "powerpc-apple-macos";
-    libc = "retro68";
+    libc = null;
     parsed = {
       cpu = {
         name = "powerpc";

--- a/nix/platforms.nix
+++ b/nix/platforms.nix
@@ -14,6 +14,8 @@
         name = "macos";
         execFormat = { name = "unknown"; };
       };
+      vendor = { name = "apple"; };
+      abi = { name = "macos"; };
     };
     bfdEmulation = "m68k";
     isStatic = true;
@@ -37,6 +39,8 @@
         name = "macos";
         execFormat = { name = "unknown"; };
       };
+      vendor = { name = "apple"; };
+      abi = { name = "macos"; };
     };
 
     isStatic = true;
@@ -60,6 +64,8 @@
         name = "carbon";
         execFormat = { name = "unknown"; };
       };
+      vendor = { name = "apple"; };
+      abi = { name = "macos"; };
     };
     isStatic = true;
     retro68BinutilsConfig = [ "--disable-plugins" ];
@@ -67,9 +73,4 @@
     retro68 = true;
     cmakeSystemName = "RetroCarbon";
   };
-
-  isStatic = true;
-  retro68BinutilsConfig = [ "--disable-plugins" ];
-  retro68GccConfig = [ "--disable-lto" ];
-  retro68 = true;
 }

--- a/nix/samples.nix
+++ b/nix/samples.nix
@@ -2,18 +2,20 @@ pkgs: prevPkgs: {
   retro68 = prevPkgs.retro68.overrideScope' (self: prevRetro: {
     samples = with pkgs;
       let
-        individualSamples = lib.mapAttrs (key: path:
-          stdenv.mkDerivation {
-            name = "retro68.samples." + key;
-            src = path;
-            nativeBuildInputs = [ buildPackages.ninja buildPackages.cmake ];
-            buildInputs = [ retro68.console ];
-            installPhase = ''
-              mkdir $out
-              cp *.bin $out/
-              rm -f $out/*.code.bin $out/*.rsrc.bin
-            '';
-          }) ({
+        individualSamples = lib.mapAttrs
+          (key: path:
+            stdenv.mkDerivation {
+              name = "retro68.samples." + key;
+              src = path;
+              nativeBuildInputs = [ buildPackages.ninja buildPackages.cmake ];
+              buildInputs = [ retro68.console ];
+              installPhase = ''
+                mkdir $out
+                cp *.bin $out/
+                rm -f $out/*.code.bin $out/*.rsrc.bin
+              '';
+            })
+          ({
             dialog = ../Samples/Dialog;
             helloworld = ../Samples/HelloWorld;
             raytracer = ../Samples/Raytracer;
@@ -25,8 +27,9 @@ pkgs: prevPkgs: {
           } // lib.optionalAttrs (targetPlatform.cmakeSystemName == "Retro68") {
             systemextension = ../Samples/SystemExtension;
             launcher = ../Samples/Launcher;
-          }) // { launchapplserver =  self.launchapplserver; };
-      in runCommand "retro68.samples" { } ''
+          }) // { launchapplserver = self.launchapplserver; };
+      in
+      runCommand "retro68.samples" { } ''
         mkdir -p $out/
 
         ${lib.concatMapStrings (x: ''

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "autc04",
         "repo": "multiversal",
-        "rev": "ce33b1bada9b0acb14021c21ac916927c757d525",
-        "sha256": "1fsyjad4kwsqgr2mlx9dfl7z8z42cf2sgw1arqmci47zhaj8is1f",
+        "rev": "1170bce4c98f1956ad73ca335479d510cd6e8620",
+        "sha256": "040vi7c2wggaazm2nrjvzrkn10sgmsbrcpmj2gi1ynjf4awxiqkw",
         "type": "tarball",
-        "url": "https://github.com/autc04/multiversal/archive/ce33b1bada9b0acb14021c21ac916927c757d525.tar.gz",
+        "url": "https://github.com/autc04/multiversal/archive/1170bce4c98f1956ad73ca335479d510cd6e8620.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "5830a4dd348d77e39a0f3c4c762ff2663b602d4c",
-        "sha256": "1d3lsrqvci4qz2hwjrcnd8h5vfkg8aypq3sjd4g3izbc8frwz5sm",
+        "rev": "6bd7cd686220bf3db0e212481faf9578e8c8ff0f",
+        "sha256": "15claxlj6y15db67qc7kb4vzyn6sv7r13z4q502vq7a4z2488z94",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/5830a4dd348d77e39a0f3c4c762ff2663b602d4c.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/6bd7cd686220bf3db0e212481faf9578e8c8ff0f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d1e59cfc49961e121583abe32e2f3db1550fbcff",
-        "sha256": "03ldf1dlxqf3g8qh9x5vp6vd9zvvr481fyjds111imll69y60wpm",
+        "rev": "2766f77c32e171a04d59b636a91083bae862274e",
+        "sha256": "1xk1f62n00z7q5i3pf4c8c4rlv5k4jwpgh0pqgzw1l40vhdkixk9",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/d1e59cfc49961e121583abe32e2f3db1550fbcff.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/2766f77c32e171a04d59b636a91083bae862274e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "autc04",
         "repo": "multiversal",
-        "rev": "1170bce4c98f1956ad73ca335479d510cd6e8620",
-        "sha256": "040vi7c2wggaazm2nrjvzrkn10sgmsbrcpmj2gi1ynjf4awxiqkw",
+        "rev": "27c08c654bbd48d23f025741e3a584b59374904a",
+        "sha256": "1b022pvpjw3n6713zq09abgbm0iba6lr16czhjxi1yk23xchny0s",
         "type": "tarball",
-        "url": "https://github.com/autc04/multiversal/archive/1170bce4c98f1956ad73ca335479d510cd6e8620.tar.gz",
+        "url": "https://github.com/autc04/multiversal/archive/27c08c654bbd48d23f025741e3a584b59374904a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
@@ -24,15 +24,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "release-21.11",
+        "branch": "nixos-23.11",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2766f77c32e171a04d59b636a91083bae862274e",
-        "sha256": "1xk1f62n00z7q5i3pf4c8c4rlv5k4jwpgh0pqgzw1l40vhdkixk9",
+        "rev": "0b3d618173114c64ab666f557504d6982665d328",
+        "sha256": "1p941x8rx6hq8zrcmwnw6rnxd4v0v7vn1v5a763lmjxcfglz965b",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/2766f77c32e171a04d59b636a91083bae862274e.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0b3d618173114c64ab666f557504d6982665d328.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/universal.nix
+++ b/nix/universal.nix
@@ -53,7 +53,6 @@ pkgs: prevPkgs:
           '');
         };
     });
-} // prevPkgs.lib.optionalAttrs (prevPkgs.targetPlatform ? retro68) {
 
   stdenvUniversal = pkgs.stdenv.override {
     cc = pkgs.stdenv.cc.override {

--- a/nix/universal.nix
+++ b/nix/universal.nix
@@ -1,58 +1,59 @@
 pkgs: prevPkgs:
 {
-  retro68 = if !(prevPkgs.hostPlatform ? retro68) then
-    prevPkgs.retro68
-  else
-    prevPkgs.retro68.overrideScope' (self: prevRetro: {
+  retro68 =
+    if !(prevPkgs.hostPlatform ? retro68) then
+      prevPkgs.retro68
+    else
+      prevPkgs.retro68.overrideScope' (self: prevRetro: {
 
-      mpw_35_gm = with pkgs;
-        fetchurl {
-          url =
-            "https://web.archive.org/web/20210309154524/https://staticky.com/mirrors/ftp.apple.com/developer/Tool_Chest/Core_Mac_OS_Tools/MPW_etc./MPW-GM_Images/MPW-GM.img.bin";
-          sha256 = "0wm8dwmm0cpp8px27in564ih27sn5vbydz3jqpzwh04qpfazmfwr";
-        };
+        mpw_35_gm = with pkgs;
+          fetchurl {
+            url =
+              "https://web.archive.org/web/20210309154524/https://staticky.com/mirrors/ftp.apple.com/developer/Tool_Chest/Core_Mac_OS_Tools/MPW_etc./MPW-GM_Images/MPW-GM.img.bin";
+            sha256 = "0wm8dwmm0cpp8px27in564ih27sn5vbydz3jqpzwh04qpfazmfwr";
+          };
 
-      universal = with pkgs;
-        stdenvNoCC.mkDerivation {
-          name = "retro68.universal";
-          src = retro68.mpw_35_gm;
-          nativeBuildInputs = with buildPackages.retro68; [
-            tools
-            hfsutils
-            binutils_unwrapped
-          ];
+        universal = with pkgs;
+          stdenvNoCC.mkDerivation {
+            name = "retro68.universal";
+            src = retro68.mpw_35_gm;
+            nativeBuildInputs = with buildPackages.retro68; [
+              tools
+              hfsutils
+              binutils_unwrapped
+            ];
 
-          buildCommand = ''
-            ConvertDiskImage $src decoded.dsk
-            export HOME=.
-            hmount decoded.dsk
-            mkdir -p CIncludes RIncludes
-            hcopy -t 'MPW-GM:MPW-GM:Interfaces&Libraries:Interfaces:CIncludes:*.h' CIncludes/
-            hcopy -t 'MPW-GM:MPW-GM:Interfaces&Libraries:Interfaces:RIncludes:*.r' RIncludes/
-            mkdir -p $out/include $out/RIncludes
-            bash ${../prepare-headers.sh} CIncludes $out/include
-            bash ${../prepare-rincludes.sh} RIncludes $out/RIncludes
+            buildCommand = ''
+              ConvertDiskImage $src decoded.dsk
+              export HOME=.
+              hmount decoded.dsk
+              mkdir -p CIncludes RIncludes
+              hcopy -t 'MPW-GM:MPW-GM:Interfaces&Libraries:Interfaces:CIncludes:*.h' CIncludes/
+              hcopy -t 'MPW-GM:MPW-GM:Interfaces&Libraries:Interfaces:RIncludes:*.r' RIncludes/
+              mkdir -p $out/include $out/RIncludes
+              bash ${../prepare-headers.sh} CIncludes $out/include
+              bash ${../prepare-rincludes.sh} RIncludes $out/RIncludes
 
-            . ${../interfaces-and-libraries.sh}
-          '' + (pkgs.lib.optionalString (pkgs.targetPlatform.cmakeSystemName == "Retro68")  ''
-            mkdir -p lib68
-            hcopy -r 'MPW-GM:MPW-GM:Interfaces&Libraries:Libraries:Libraries:*.o' lib68
-            M68KLIBRARIES=lib68
-            setup68KLibraries $out/
-            mv $out/lib68k $out/lib
-          '') + (pkgs.lib.optionalString (pkgs.targetPlatform.cmakeSystemName != "Retro68")  ''
-            mkdir -p libppc peflibs
-            hcopy -r 'MPW-GM:MPW-GM:Interfaces&Libraries:Libraries:PPCLibraries:*.o' libppc
-            hcopy -m 'MPW-GM:MPW-GM:Interfaces&Libraries:Libraries:SharedLibraries:*' peflibs
-            PPCLIBRARIES=libppc
-            SHAREDLIBRARIES=peflibs
-            INTERFACELIB=peflibs/InterfaceLib.bin
+              . ${../interfaces-and-libraries.sh}
+            '' + (pkgs.lib.optionalString (pkgs.targetPlatform.cmakeSystemName == "Retro68") ''
+              mkdir -p lib68
+              hcopy -r 'MPW-GM:MPW-GM:Interfaces&Libraries:Libraries:Libraries:*.o' lib68
+              M68KLIBRARIES=lib68
+              setup68KLibraries $out/
+              mv $out/lib68k $out/lib
+            '') + (pkgs.lib.optionalString (pkgs.targetPlatform.cmakeSystemName != "Retro68") ''
+              mkdir -p libppc peflibs
+              hcopy -r 'MPW-GM:MPW-GM:Interfaces&Libraries:Libraries:PPCLibraries:*.o' libppc
+              hcopy -m 'MPW-GM:MPW-GM:Interfaces&Libraries:Libraries:SharedLibraries:*' peflibs
+              PPCLIBRARIES=libppc
+              SHAREDLIBRARIES=peflibs
+              INTERFACELIB=peflibs/InterfaceLib.bin
 
-            setupPPCLibraries $out/
-            mv $out/libppc $out/lib
-          '');
-        };
-    });
+              setupPPCLibraries $out/
+              mv $out/libppc $out/lib
+            '');
+          };
+      });
 
   stdenvUniversal = pkgs.stdenv.override {
     cc = pkgs.stdenv.cc.override {


### PR DESCRIPTION
switch to nix flakes.

[Nix](nixos.org) users can now use `nix develop github:autc04/Retro68#m68k` to get a dev shell without installing Retro68 first.