### PR TITLE
Set a valid timestamp on MacBinary output

### DIFF
--- a/ResourceFiles/ResourceFile.cc
+++ b/ResourceFiles/ResourceFile.cc
@@ -3,6 +3,8 @@
 
 #include <boost/filesystem.hpp>
 #include "boost/filesystem/fstream.hpp"
+#include <chrono>
+#include <ctime>
 #include <sstream>
 #include <iostream>
 
@@ -73,6 +75,13 @@ static void writeMacBinary(std::ostream& out, std::string filename,
 
     const std::string& rsrcBytes = resstream.str();
 
+    // Calculate Mac-style timestamp (seconds since 1 January 1904 00:00:00)
+    std::tm mac_epoch_tm = {
+        0, 0, 0, // 00:00:00
+        1, 0, 4  // 1 January 1904
+    };
+    auto mac_epoch = std::chrono::system_clock::from_time_t(std::mktime(&mac_epoch_tm));
+    uint32_t mac_time = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - mac_epoch).count();
 
     std::ostringstream header;
     byte(header, 0);
@@ -91,8 +100,8 @@ static void writeMacBinary(std::ostream& out, std::string filename,
     byte(header, 0);
     longword(header, (int)data.size());
     longword(header, (int)rsrcBytes.size());
-    longword(header, 0); // creation date
-    longword(header, 0); // modification date
+    longword(header, mac_time); // creation date
+    longword(header, mac_time); // modification date
     while((int)header.tellp() < 124)
         byte(header,0);
     std::string headerData = header.str();


### PR DESCRIPTION
Previously, `ResourceFile.cc` set the creation and modification timestamp of the MacBinary header to 0, which meant that the extracted file would always have a bogus timestamp of 00:00:00 01/01/1904. In most cases this is just cosmetic, but my ethernet-driver project will use Apple's Installer to install and update its components, and without valid timestamps, updates could be problematic.

This patch gives me a 'good enough' behavior from my perspective (MacBinary-wrapped files have a creation and modification date roughly matching the creation of the MacBinary container), but I realise that it's not a completely correct solution - for example, if Rez is appending to an existing MacBinary-wrapped resource file, the creation date should probably remain the same. But I think it's more correct than having a timestamp 100 years in the past :)