### PR TITLE
Dockerfile: update Ubuntu base image from 20.04 to 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # vim:ft=dockerfile
 
 # Base image
-FROM ubuntu:20.04 AS base
+FROM ubuntu:22.04 AS base
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         cmake libgmp-dev libmpfr-dev libmpc-dev \
-        libboost-all-dev bison texinfo \
+        libboost-all-dev bison texinfo bzip2 \
         ruby flex curl g++ git macutils
 
 # Add toolchain to default PATH


### PR DESCRIPTION
The current CI build for Linux fails with the following error:

```
2791.4 Scanning dependencies of target ResourceFiles 2791.4 [ 68%] Building CXX object ResourceFiles/CMakeFiles/ResourceFiles.dir/ResourceFork.cc.o 2791.4 [ 69%] Building CXX object ResourceFiles/CMakeFiles/ResourceFiles.dir/BinaryIO.cc.o 2791.4 [ 69%] Building CXX object ResourceFiles/CMakeFiles/ResourceFiles.dir/ResType.cc.o 2791.4 [ 70%] Building CXX object ResourceFiles/CMakeFiles/ResourceFiles.dir/ResourceFile.cc.o ------
Dockerfile:21
--------------------
  20 |
  21 | >>> RUN mkdir /Retro68-build && \
  22 | >>>     mkdir /Retro68-build/bin && \
  23 | >>>     bash -c "cd /Retro68-build && bash /Retro68/build-toolchain.bash"
```

Looking back through the logs there is no sign of any specific error, however the CI history indicates that the problem was introduced via commit e187bd21c2 ("honor SOURCE_DATE_EPOCH variable when timestamping MacBinary files").

A bit of searching suggests a couple of possible reasons as to why commit e187bd21c2 could introduce a build failure: 1) the version of gcc being used may have a buggy/incomplete implementation of std::chrono or 2) a bug in the version of cmake.

On this basis updating the Ubuntu base image from 20.04 (old LTS) to 22.04 (current LTS) should resolve these issues, and indeed with this change applied I can successfully build the container image from current Retro68 git as well as one of the sample applications.