### PR TITLE
Define "macintosh" and "Macintosh"

### DIFF
--- a/gcc/gcc/config/m68k/m68k-macos.h
+++ b/gcc/gcc/config/m68k/m68k-macos.h
@@ -16,3 +16,11 @@
 #undef CPP_SPEC
 #define CPP_SPEC "-Wno-trigraphs"
 
+#undef TARGET_OS_CPP_BUILTINS
+#define TARGET_OS_CPP_BUILTINS()          \
+  do                                      \
+    {                                     \
+      builtin_define ("macintosh");       \
+      builtin_define ("Macintosh");       \
+    }                                     \
+  while (0)

--- a/gcc/gcc/config/rs6000/macos.h
+++ b/gcc/gcc/config/rs6000/macos.h
@@ -152,6 +152,8 @@
       builtin_define ("__PPC__");               \
       builtin_define ("__POWERPC__");           \
       builtin_define ("__NATURAL_ALIGNMENT__"); \
+      builtin_define ("macintosh");             \
+      builtin_define ("Macintosh");             \
       builtin_assert ("system=macos");     \
       builtin_assert ("cpu=powerpc");     \
       builtin_assert ("machine=powerpc"); \


### PR DESCRIPTION
See https://sourceforge.net/p/predef/wiki/OperatingSystems/ for rationale.

I examined the Python 2.0.1 code (https://www.python.org/ftp/python/2.0.1/Python-2.0.1.tgz), from 2001, and found a lot of `#ifdef macintosh`, so I think this is legit.

This fixes #209.