### PR TITLE
Fixes include poisoning on sonoma

### DIFF
--- a/gcc/gcc/system.h
+++ b/gcc/gcc/system.h
@@ -194,28 +194,6 @@ extern int fprintf_unlocked (FILE *, const char *, ...);
 #undef fread_unlocked
 #undef fwrite_unlocked
 
-/* Include <string> before "safe-ctype.h" to avoid GCC poisoning
-   the ctype macros through safe-ctype.h */
-
-#ifdef __cplusplus
-#ifdef INCLUDE_STRING
-# include <string>
-#endif
-#endif
-
-/* There are an extraordinary number of issues with <ctype.h>.
-   The last straw is that it varies with the locale.  Use libiberty's
-   replacement instead.  */
-#include "safe-ctype.h"
-
-#include <sys/types.h>
-
-#include <errno.h>
-
-#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
-extern int errno;
-#endif
-
 #ifdef __cplusplus
 #if defined (INCLUDE_ALGORITHM) || !defined (HAVE_SWAP_IN_UTILITY)
 # include <algorithm>
@@ -228,6 +206,11 @@ extern int errno;
 #endif
 #ifdef INCLUDE_SET
 # include <set>
+#endif
+/* Include <string> before "safe-ctype.h" to avoid GCC poisoning
+   the ctype macros through safe-ctype.h */
+#ifdef INCLUDE_STRING
+# include <string>
 #endif
 #ifdef INCLUDE_VECTOR
 # include <vector>
@@ -243,6 +226,17 @@ extern int errno;
 # include <new>
 # include <utility>
 # include <type_traits>
+#endif
+
+/* There are an extraordinary number of issues with <ctype.h>.
+   The last straw is that it varies with the locale.  Use libiberty's
+   replacement instead.  */
+#include "safe-ctype.h"
+#include <sys/types.h>
+#include <errno.h>
+
+#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
+extern int errno;
 #endif
 
 /* Some of glibc's string inlines cause warnings.  Plus we'd rather

--- a/gcc/libcc1/libcc1plugin.cc
+++ b/gcc/libcc1/libcc1plugin.cc
@@ -31,6 +31,7 @@
 #undef PACKAGE_TARNAME
 #undef PACKAGE_VERSION
 
+#define INCLUDE_VECTOR
 #define INCLUDE_MEMORY
 #include "gcc-plugin.h"
 #include "system.h"
@@ -69,7 +70,6 @@
 #include "gcc-c-interface.h"
 #include "context.hh"
 
-#include <vector>
 
 using namespace cc1_plugin;
 

--- a/gcc/libcc1/libcp1plugin.cc
+++ b/gcc/libcc1/libcp1plugin.cc
@@ -33,6 +33,7 @@
 #undef PACKAGE_VERSION
 
 #define INCLUDE_MEMORY
+#define INCLUDE_VECTOR
 #include "gcc-plugin.h"
 #include "system.h"
 #include "coretypes.h"
@@ -71,7 +72,6 @@
 #include "rpc.hh"
 #include "context.hh"
 
-#include <vector>
 
 using namespace cc1_plugin;
 


### PR DESCRIPTION
Retro68 does not build on sonoma due to type poisoning. This commit is basically a backport of the patches made for gcc-14 which solves the issue. 

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111632
