### PR TITLE
Regenerate autoconf to allow building with clang-16

### DIFF
--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -194,7 +194,13 @@ locateAndCheckInterfacesAndLibraries
 ##################### Third-Party components: binutils, gcc, hfsutils
 
 if [ $SKIP_THIRDPARTY != true ]; then
+	# (Re)generate autoconf scripts to be compliant with installed host toolchain
+	TEMP=$(pwd)
+	cd "$SRC"
+	find . -name "configure.in" -execdir autoconf \;
+	cd "$TEMP"
 
+	# Create or replace prefix folder
 	if [ "$PREFIX" = "$DEFAULT_PREFIX" ]; then
 		# Remove old install tree
 		rm -rf $PREFIX
@@ -297,7 +303,6 @@ if [ $SKIP_THIRDPARTY != true ]; then
 
 	unset CPPFLAGS
 	unset LDFLAGS
-
 
 	# Build hfsutil
 	mkdir -p $PREFIX/lib


### PR DESCRIPTION
Added a step that (re)generates all configure files in the project upon bootstrapping,
This is due to a breaking change in clang 16 where implicit int is treated as an error starting with clang16 (late clang15 when using Apples SDK on AArch64).

This change may require additions to the README though as autoconf/automake has to be installed for this to be performed successfully, another option would be to commit the newly generated configures but I'm uncertain if they're backwards compatible, it's not recommended to use pre-generated configure scripts just because of reasons that different toolchains may need alterations in the config script. 

In this particular-case it's the builtin PROG_CC macro that checks for a working compiler that is broken, as the check is performed by "main(){return 0;}" which triggers the explicit int return error.

https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html#potentially-breaking-changes