### PR TITLE
Fix compilation of empty resources as generated by MPW's DeRez

### DIFF
--- a/Rez/RezParser.yy
+++ b/Rez/RezParser.yy
@@ -500,10 +500,14 @@ resource_item	: value { $$ = $1; }
 				;
 
 
-data : "data" res_spec "{" string_expression "}"
-{
-	world.addData($res_spec, $string_expression->evaluateString(nullptr), @1);
-}
-;
+data	: "data" res_spec "{" string_expression "}"
+			{
+				world.addData($res_spec, $string_expression->evaluateString(nullptr), @1);
+			}
+		| "data" res_spec "{" "}"
+			{
+				world.addData($res_spec, "", @1);
+			}
+		;
 
 %%


### PR DESCRIPTION
MPW's DeRez command will produce empty resources in this format:

```
data 'ABCD' (128, "some resource name") {
};
```
Currently Retro68's reimplementation of Rez will see this as a syntax error. This PR makes a small change to RezParser to allow that syntax.

There are actually situations in classic mac apps where you're supposed to have a completely empty resource, namely when including a `FONT` resource. Each font family needs to have one extra `FONT` resource representing the family itself, and it contains no data.

(This is my first time working with Bison grammar, so please double check my work!)