### PR TITLE
Minor docker updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ $ docker run --rm -v $(pwd):/root \
 EOF
 ```
 
-Note that `entrypoint.sh` checks to see if the universal interfaces are installed into
+Note that `docker-entrypoint.sh` checks to see if the universal interfaces are installed into
 `/Retro68/toolchain/universal` first before attempting to access the file or URL specified
 by INTERFACESFILE. This means that it is possible to use caching or another volume so that
 the universal interfaces are only processed once to speed up builds e.g.

--- a/install-universal-interfaces.sh
+++ b/install-universal-interfaces.sh
@@ -65,31 +65,13 @@ while IFS= read -r LINE; do
                UNIXFULLPATH="$UNIXPATH$LINE"
 
                echo "Copying $HFSFULLPATH to $UNIXFULLPATH"
-
-               # PPC libraries need a resource fork, but the code in
-               # interfaces-and-libraries.sh doesn't correctly detect InterfaceLib in
-               # Macbinary format. Work around this for now by using Basilisk II format
-               # which can be parsed by ResourceFile and still allows the filename
-               # detection logic to work.
                if [[ $HFSPATH == *SharedLibraries: ]];
                then
-                   if [[ ! -d $UNIXPATH.rsrc ]];
-                   then
-                       mkdir $UNIXPATH.rsrc
-                   fi
-
-                   # First copy as Macbinary
+                   # interfaces-and-libraries.sh can detect and use PPC libraries in
+                   # MacBinary format
                    hcopy -m $HFSFULLPATH $UNIXFULLPATH.bin
-
-                   # Extract data fork using normal name
-                   bash -c "cd $UNIXPATH && macunpack -d $UNIXFULLPATH.bin && mv $UNIXFULLPATH.data $UNIXFULLPATH"
-
-                   # Extract resource fork into .rsrc directory
-                   bash -c "cd $UNIXPATH && macunpack -r $UNIXFULLPATH.bin && mv $UNIXFULLPATH.rsrc $UNIXPATH.rsrc/$LINE"
-
-                   # Delete original Macbinary
-                   rm -rf $UNIXFULLPATH.bin
                else
+                   # Otherwise copy files in raw format
                    hcopy -r $HFSFULLPATH $UNIXFULLPATH
                fi
            fi


### PR DESCRIPTION
Here are a couple of self-explanatory minor docker updates based upon the latest Retro68 repository master branch.

The first patch updates `README.md` to reflect the rename of `entrypoint.sh` to `docker-entrypoint.sh` that occurred just before merge, whilst the second patch removes a workaround in `install-universal-interfaces.sh` when using MacBinary libraries with Universal Interfaces in the docker image.