### PR TITLE
"Change BUILD_JOBS=8" to match the threads on the computer itself.

### DIFF
--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -23,7 +23,7 @@ SRC=$(cd `dirname $0` && pwd -P)
 DEFAULT_PREFIX=`pwd -P`/toolchain/
 PREFIX=$DEFAULT_PREFIX
 BINUTILS=`pwd -P`/binutils-build
-BUILD_JOBS=8
+BUILD_JOBS=$(nproc | sysctl -n hw.physicalcpu)
 if [ $(uname) == "Linux" ]; then
     BUILD_JOBS=$(grep processor /proc/cpuinfo | wc -l)
 fi

--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -23,7 +23,7 @@ SRC=$(cd `dirname $0` && pwd -P)
 DEFAULT_PREFIX=`pwd -P`/toolchain/
 PREFIX=$DEFAULT_PREFIX
 BINUTILS=`pwd -P`/binutils-build
-BUILD_JOBS=$(nproc | sysctl -n hw.physicalcpu)
+BUILD_JOBS=$(nproc || sysctl -n hw.physicalcpu)
 
 ##################### Prerequisites check
 

--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -24,9 +24,6 @@ DEFAULT_PREFIX=`pwd -P`/toolchain/
 PREFIX=$DEFAULT_PREFIX
 BINUTILS=`pwd -P`/binutils-build
 BUILD_JOBS=$(nproc | sysctl -n hw.physicalcpu)
-if [ $(uname) == "Linux" ]; then
-    BUILD_JOBS=$(grep processor /proc/cpuinfo | wc -l)
-fi
 
 ##################### Prerequisites check
 


### PR DESCRIPTION
Because I wasted two hours today compiling this on the only Mac I have access to - one with a dual core i3 - before remembering that the build script has the build jobs set to 8, which makes the process worse then if i'd just used one core. I finished it in 30 minutes by switching it to what is shown below.

This patch accommodates Mac, Linux, and the people emulating Linux under Windows.