### PR TITLE
Specify return type of main() in conftest.c

### DIFF
--- a/hfsutils/configure
+++ b/hfsutils/configure
@@ -711,7 +711,7 @@ cross_compiling=$ac_cv_prog_cc_cross
 cat > conftest.$ac_ext <<EOF
 #line 713 "configure"
 #include "confdefs.h"
-main(){return(0);}
+int main(){return(0);}
 EOF
 if { (eval echo configure:717: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest; then
   ac_cv_prog_cc_works=yes

--- a/hfsutils/libhfs/configure
+++ b/hfsutils/libhfs/configure
@@ -657,7 +657,7 @@ cross_compiling=$ac_cv_prog_cc_cross
 cat > conftest.$ac_ext <<EOF
 #line 659 "configure"
 #include "confdefs.h"
-main(){return(0);}
+int main(){return(0);}
 EOF
 if { (eval echo configure:663: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest; then
   ac_cv_prog_cc_works=yes
@@ -1278,7 +1278,7 @@ else
 #line 1279 "configure"
 #include "confdefs.h"
 
-main()
+int main()
 {
   char c0 = 0x40, c1 = 0x80, c2 = 0x81;
   exit(memcmp(&c0, &c2, 1) < 0 && memcmp(&c1, &c2, 1) < 0 ? 0 : 1);

--- a/hfsutils/librsrc/configure
+++ b/hfsutils/librsrc/configure
@@ -657,7 +657,7 @@ cross_compiling=$ac_cv_prog_cc_cross
 cat > conftest.$ac_ext <<EOF
 #line 659 "configure"
 #include "confdefs.h"
-main(){return(0);}
+int main(){return(0);}
 EOF
 if { (eval echo configure:663: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest; then
   ac_cv_prog_cc_works=yes


### PR DESCRIPTION
This PR fixes following error while building on macOS.

```
error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
main(){return(0);}
^
```
