### PR TITLE
Reduce high CPU when sitting idle at the console.

### DIFF
--- a/Console/retro/ConsoleWindow.cc
+++ b/Console/retro/ConsoleWindow.cc
@@ -29,6 +29,7 @@
 #include <functional>
 #include <OSUtils.h>
 #include <Traps.h>
+#include <Patches.h>
 
 using namespace std;
 using namespace retro;

--- a/Console/retro/ConsoleWindow.cc
+++ b/Console/retro/ConsoleWindow.cc
@@ -29,7 +29,6 @@
 #include <functional>
 #include <OSUtils.h>
 #include <Traps.h>
-#include <Patches.h>
 
 using namespace std;
 using namespace retro;
@@ -180,6 +179,8 @@ bool waitNextEventWrapper(EventRecord *event)
 // Determines if a Toolbox routine is available
 bool routineAvailable(int trapWord) {
     TrapType trType;
+    int OSTrap = 0;
+    int ToolTrap = 1;
 
     // Determine whether it is an Operating System or Toolbox routine
     if ((trapWord & 0x0800) == 0) {


### PR DESCRIPTION
Currently when a console-based program is waiting for user input, its CPU usage is very high. This is because it uses a call to GetNextEvent(). This function does not provide any sleep abilities. To fix this problem we determine at runtime if the WaitNextEvent() function is available. If it is then it is used. WaitNextEvent() does provide a sleep value to enable low CPU usage when the program that uses it is running. If you wish to use your program on a system without the WaitNextEvent() function then the GetNextEvent() function is used instead. This patch has been tested with Carbon, PowerPC, and 68k targets. The programs that implemented this patch have been tested on Mac OS 10.4, the classic environment, and Mini vMac running System 6.0.8 successfully.