### PR TITLE
Fix GCC 15 compilation error in ConvertDiskImage

### DIFF
--- a/ConvertDiskImage/ConvertDiskImage.cc
+++ b/ConvertDiskImage/ConvertDiskImage.cc
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <fstream>
 #include <cassert>
+#include <cstdint>
 #include <vector>
 
 void decompressADC(std::vector<uint8_t>& outbuf, const std::vector<uint8_t>& inbuf)


### PR DESCRIPTION
This PR fixes a compilation error that occurs with GCC 15 in `ConvertDiskImage.cc`.

## Changes
- Added `#include <cstdint>` to ConvertDiskImage/ConvertDiskImage.cc

## Problem
GCC 15 removed transitive includes of `<cstdint>`, causing fixed-width integer types like `uint8_t` to be undefined when not explicitly included. This resulted in compilation failures when building with GCC 15.

Fixes #296