### PR TITLE
Build with number of active (not physical) CPUs

### DIFF
--- a/build-toolchain.bash
+++ b/build-toolchain.bash
@@ -23,7 +23,7 @@ SRC=$(cd `dirname $0` && pwd -P)
 DEFAULT_PREFIX=`pwd -P`/toolchain/
 PREFIX=$DEFAULT_PREFIX
 BINUTILS=`pwd -P`/binutils-build
-BUILD_JOBS=$(nproc || sysctl -n hw.physicalcpu)
+BUILD_JOBS=$(nproc || sysctl -n hw.activecpu)
 
 ##################### Prerequisites check
 


### PR DESCRIPTION
Some physical CPUs might not be active.